### PR TITLE
Features: DAI Basic DHCP Snooping and ARP Validation with DENT

### DIFF
--- a/main.c
+++ b/main.c
@@ -2,6 +2,8 @@
 #include "dhcp.h"
 #include "errno.h"
 
+#include <linux/netfilter_bridge.h>
+
 MODULE_LICENSE("GPL");
 MODULE_AUTHOR("M. Sami GURPINAR <sami.gurpinar@gmail.com>");
 MODULE_DESCRIPTION("kdai(Kernel Dynamic ARP Inspection) is a linux kernel module to defend against arp spoofing");
@@ -219,9 +221,9 @@ static int __init kdai_init(void) {
         goto err;
     
     arpho->hook = (nf_hookfn *) arp_hook;       /* hook function */
-    arpho->hooknum = NF_ARP_IN;                 /* received packets */
-    arpho->pf = NFPROTO_ARP;                    /* ARP */
-    arpho->priority = NF_IP_PRI_FIRST;
+    arpho->hooknum = NF_BR_PRE_ROUTING;         /* received packets */
+    arpho->pf = NFPROTO_BRIDGE;                 /* ARP */
+    arpho->priority = NF_BR_PRI_FIRST;
     #if LINUX_VERSION_CODE >= KERNEL_VERSION(4,13,0)
         nf_register_net_hook(&init_net, arpho);
     #else
@@ -234,9 +236,9 @@ static int __init kdai_init(void) {
         goto err;
     
     ipho->hook = (nf_hookfn *) ip_hook;         /* hook function */
-    ipho->hooknum = NF_INET_PRE_ROUTING;        /* received packets */
-    ipho->pf = NFPROTO_IPV4;                    /* IP */
-    ipho->priority = NF_IP_PRI_FIRST;
+    ipho->hooknum = NF_BR_PRE_ROUTING;          /* received packets */
+    ipho->pf = NFPROTO_BRIDGE;                  /* IP */
+    ipho->priority = NF_BR_PRI_FIRST;
     #if LINUX_VERSION_CODE >= KERNEL_VERSION(4,13,0)
         nf_register_net_hook(&init_net, ipho);
     #else

--- a/main.c
+++ b/main.c
@@ -167,9 +167,11 @@ static int arp_is_valid(struct sk_buff* skb, u16 ar_op, unsigned char* sha,
     memcpy(shaddr, eth->h_source, ETH_ALEN);
     memcpy(dhaddr, eth->h_dest, ETH_ALEN);
 
+    //This is an optional feature that may be uncommented if administrators choose to.
+    //On Cisco devices this optional check known as “ip arp inspection validate src-mac”. 
     if (memcmp(sha, shaddr, ETH_ALEN) != 0) {
-        printk(KERN_ERR "kdai: the sender MAC address %pM in the message body is NOT identical to the source MAC address in the Ethernet header %pM\n", sha, shaddr);
-        return -EHWADDR;
+        //printk(KERN_ERR "kdai: the sender MAC address %pM in the message body is NOT identical to the source MAC address in the Ethernet header %pM\n", sha, shaddr);
+        //return -EHWADDR;
     } 
 
     if (ipv4_is_multicast(sip)) {

--- a/main.c
+++ b/main.c
@@ -89,10 +89,13 @@ static unsigned int ip_hook(void* priv, struct sk_buff* skb, const struct nf_hoo
     udp = udp_hdr(skb);
     
     if (udp->source == htons(DHCP_SERVER_PORT) || udp->source == htons(DHCP_CLIENT_PORT)) {
+        printk(KERN_INFO "\nkdai: !! Hooked IP PACKET !!");
         payload = (struct dhcp*) ((unsigned char *)udp + sizeof(struct udphdr));
         
         if (dhcp_is_valid(skb) == 0) {
+            printk(KERN_INFO "kdai: Saw a valid DHCPACK\n");
             memcpy(&dhcp_packet_type, &payload->bp_options[2], 1);
+            printk(KERN_INFO "kdai: DHCP packet type: %u\n", dhcp_packet_type);
             
             switch (dhcp_packet_type) {
                 case DHCP_ACK:{
@@ -141,6 +144,7 @@ static unsigned int ip_hook(void* priv, struct sk_buff* skb, const struct nf_hoo
                     break;
                 }
             default:
+                printk(KERN_INFO "kdai: DHCP defaulted to break\n");
                 break;
             }
       


### PR DESCRIPTION
This Pull Request (PR) introduces several important changes necessary for basic DHCP Snooping and ARP Validation with DENT in bridged environments. 

- The Netfilter hooks were modified to ensure compatibility with bridge devices, addressing issues where DHCP and ARP packets were not processed correctly when passing through a bridge. 

- Additionally, a check for mismatched sender MAC addresses in ARP messages and Ethernet headers, similar to Cisco's DAI optional "ip arp inspection validate src-mac" feature, was commented out. This check, while useful for ARP spoofing prevention, may interfere with DHCP snooping in bridged setups. The code has been left in place to allow users to enable or disable it as needed. 

- Moreover, the previous check for matching target IP addresses to the current device was removed, as it prevented forwarding of packets that weren't intended for the bridge itself, this caused issues with DHCP Snooping. 

- Finally, log updates were made to provide better visibility into ARP and DHCP packet activity. 