### PR TITLE
Refactor Module Installation and Removal process

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,8 +10,11 @@ all:
 	make -C ${KDIR} M=${PWD} modules
 	rm -r -f *.mod.c .*.cmd *.symvers *.o
 install:
-	sudo insmod ${MODULE}.ko
+	sudo cp kdai.ko ${MDIR}/.
+	sudo depmod
+	sudo modprobe kdai
 remove:
-	sudo rmmod ${MODULE}
+	sudo modprobe -r kdai
+	sudo rm ${MDIR}/kdai.ko
 clean:
 	make -C  ${KDIR} M=${PWD} clean

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ make
 ```
 ### Install
 ```bash
-sudo insmod kdai.ko
+make install
 ```
 ### Test
 ```bash
@@ -26,4 +26,4 @@ $ dmesg | tail -5
 ```
 ### Uninstall
 ```bash
-sudo rmmod kdai
+make remove


### PR DESCRIPTION
Modified Makefile to replace 'insmod' and 'rmmod' with 'cp', 'depmod', and 'modprobe'. This improves the module installation by copying it to the correct system directory, updates dependencies with 'depmod', and uses 'modprobe' for both loading and unloading the module, ensuring support for handling kernel dependencies. The README.md has also been updated to reflect the changes.