### PR TITLE
Add Test: ARP Filtering Test with KDAI module for Unvalidated Sources

### DIFF
--- a/.github/workflows/dai-testing.yml
+++ b/.github/workflows/dai-testing.yml
@@ -73,7 +73,7 @@ jobs:
           sudo pip3 install scapy 
 
       # Ensure working Testing Environment 
-      - name: Test Malformed ARP Request and Response  
+      - name: Basic ARP Request Messages To Ensure Testing Environemnt is Setup 
         run: | 
           sudo ip netns exec ns1 python3 ./tests/ARP_Request_And_Response.py
           sudo dmesg -C
@@ -102,7 +102,41 @@ jobs:
           if [ -n "$ARP_DROP_STATUS" ]; then
             sudo echo "Test Passed!"
           else
-            sudp echo "The ARP Request was Accepted when it should not have been"
+            sudo echo "The ARP Request was Accepted when it should not have been"
+            sudo echo "Test Failed!"
+            exit 1
+          fi
+
+      # Remove Module
+      - name: Clean Up Test
+        run: |
+          sudo dmesg -C
+          make remove
+
+          
+      # Test Case 2
+      # Insert the Kernel Module
+      - name: Insert Kernel Module
+        run: make install
+
+      - name: Test Malformed ARP Request and Response
+       # Expects Malformed Arp Requests Are Dropped by Kdai
+        run: |
+          # Run the ARP Malformed Request test
+          sudo ip netns exec ns1 python3 ./tests/Test_Malformed_ARP.py
+          
+          # Check dmesg logs for the ARP drop status
+          ARP_DROP_STATUS=$(sudo dmesg | grep "ARP RETURN status was: NF_DROP")
+          
+          # Print the dmesg log for debugging purposes
+          sudo echo "dmesg logs:"
+          sudo dmesg | tail -n 20  # Print the last 20 lines of dmesg
+          
+          # If ARP was dropped correctly, the test passed
+          if [ -n "$ARP_DROP_STATUS" ]; then
+            sudo echo "Test Passed!"
+          else
+            sudo echo "The ARP Request was met with a response when it should not have been"
             sudo echo "Test Failed!"
             exit 1
           fi
@@ -112,4 +146,5 @@ jobs:
         run: |
           sudo dmesg -C
           make remove
-  
+
+

--- a/.github/workflows/dai-testing.yml
+++ b/.github/workflows/dai-testing.yml
@@ -74,5 +74,42 @@ jobs:
 
       # Ensure working Testing Environment 
       - name: Test Malformed ARP Request and Response  
-        run: sudo ip netns exec ns1 python3 ./tests/ARP_Request_And_Response.py
+        run: | 
+          sudo ip netns exec ns1 python3 ./tests/ARP_Request_And_Response.py
+          sudo dmesg -C
+
+
+      # Test Case 1
+      # Insert the Kernel Module
+      - name: Insert Kernel Module
+        run: make install
+
+      - name: Test Filtering from Unvalidated Source
+       # Expects ARP requests are Dropped by KDAI when no devices have been validated 
+       # via DHCP or Static ACL configurations. This means the regular request and response should fail
+        run: |
+          # Run the ARP request test and capture the output 
+          sudo ip netns exec ns1 python3 ./tests/ARP_Request_And_Response.py
+          
+          # Check dmesg logs for the ARP drop status
+          ARP_DROP_STATUS=$(sudo dmesg | grep "ARP RETURN status was: NF_DROP")
+          
+          # Print the dmesg log for debugging purposes
+          sudo echo "dmesg logs:"
+          sudo dmesg | tail -n 20  # Print the last 20 lines of dmesg
+          
+          # If ARP was dropped correctly, the test passed
+          if [ -n "$ARP_DROP_STATUS" ]; then
+            sudo echo "Test Passed!"
+          else
+            sudp echo "The ARP Request was Accepted when it should not have been"
+            sudo echo "Test Failed!"
+            exit 1
+          fi
+
+        # Remove Module
+      - name: Clean Up Test
+        run: |
+          sudo dmesg -C
+          make remove
   

--- a/tests/ARP_Request_And_Response.py
+++ b/tests/ARP_Request_And_Response.py
@@ -40,8 +40,6 @@ if __name__ == "__main__":
     # Running the test
     try:
         test_arp_handling()
-        print("Test passed!")
-        assert(True)
+        print("ARP Response recieved")
     except AssertionError as e:
-        print(f"Test failed!")
-        assert(False)
+        print(f"ARP response not received")

--- a/tests/Test_Malformed_ARP.py
+++ b/tests/Test_Malformed_ARP.py
@@ -1,0 +1,53 @@
+from scapy.all import ARP, Ether, srp
+
+def send_arp_request(target_ip, iface):
+    """Send ARP request and wait for a response using Scapy."""
+
+    # Create an ARP request packet
+    arp_request = ARP(pdst=target_ip, psrc="224.0.0.1")
+
+    # Create an Ethernet frame to encapsulate the ARP request
+    ether_frame = Ether(dst="ff:ff:ff:ff:ff:ff")
+
+    # Combine the Ethernet frame and ARP request
+    arp_request_packet = ether_frame / arp_request
+
+    # Send the ARP request and capture responses
+    # scapy.srp returns a tuple of two lists
+    answered, unanswered = srp(arp_request_packet, timeout=2, iface=iface, verbose=False)
+
+    # Iterate through the answered list. The answered list itself is a tuple.
+    for sent, received in answered:
+        print(f"Received ARP response from {received.psrc} ({received.hwsrc})")
+        if (received.psrc == target_ip):
+            return received
+
+    #If we did not find a recieved ARP message from the target IP the test failed
+    return None
+
+def test_malformed_arp_handling():
+    interface = "veth0"         # Adjust this to your virtual interface 
+    target_ip = "192.168.1.2"   # The IP you expect to reply to ARP requests
+
+    # Step 1: Send ARP Request and capture response
+    print(f"Sending ARP request to {target_ip}...")
+    response = send_arp_request(target_ip, interface)
+
+    # Step 2: Validate Test Results
+    # Since the Source IP address is a multicast DAI should drop the packets and no responses should be received
+    if response is not None:
+        print(f"ARP response received from: {response.psrc}")
+        assert False, "ARP Response recieved"
+    else:
+        print(f"No ARP response received from target: {target_ip}.")
+        assert True, "ARP response not received"
+
+if __name__ == "__main__":
+    # Running the test
+    try:
+        test_malformed_arp_handling()
+        print("Test passed!")
+        assert(True)
+    except AssertionError as e:
+        print(f"Test failed!")
+        assert(False)


### PR DESCRIPTION
Introduced a test case that inserts the KDAI kernel module, runs an ARP request test to verify filtering from unvalidated sources, and checks the dmesg logs for the expected drop status. If the ARP request is correctly dropped, the test passes. Additionally, cleanup steps include removing the module and clearing the dmesg logs.