### PR TITLE
Add Test: DAI Allows Communication from Acknowledged Sources

### DIFF
--- a/.github/workflows/dai-testing.yml
+++ b/.github/workflows/dai-testing.yml
@@ -179,7 +179,7 @@ jobs:
           sudo echo "dmesg logs:"
           sudo dmesg | tail -n 20  # Print the last 20 lines of dmesg
           
-          # If ARP ACCEPET was fund, then Test passed
+          # If ARP ACCEPET was found, then Test passed
           if [ -n "$ARP_DROP_STATUS" ]; then
             sudo echo "Test Passed!"
           else
@@ -197,4 +197,39 @@ jobs:
           sudo dmesg -C
           make remove
 
+      # Test Case 4
+      # Insert the Kernel Module
+      - name: Insert Kernel Module
+        run: make install
+
+      - name: Test DAI Allows communicaiton from Acknowledged Sources
+       # Expects Packet to be accepted when the server sees a DHCP ACK
+        run: |
+          # Create and send the switch a Cusotm DHCP packet ACK for both 192.168.1.1 and 192.168.1.2
+          sudo ip netns exec ns1 python3 ./tests/DHCP_Snooping.py
+
+          #Send and ARP Request and wait for a Response
+          sudo ip netns exec ns1 python3 ./tests/ARP_Request_And_Response.py
+
+          # Check dmesg logs for the ARP drop status
+          ARP_DROP_STATUS=$(sudo dmesg | grep "ARP RETURN status was: NF_ACCEPT")
+          
+          # Print the dmesg log for debugging purposes
+          sudo echo "dmesg logs:"
+          sudo dmesg | tail -n 20  # Print the last 20 lines of dmesg
+          
+          # If ARP ACCEPT was found, then Test passed
+          if [ -n "$ARP_DROP_STATUS" ]; then
+            sudo echo "Test Passed!"
+          else
+            sudo echo "The ARP Request was not met with a response"
+            sudo echo "Test Failed!"
+            exit 1
+          fi
+
+        # Remove Module
+      - name: Clean Up Test
+        run: |
+          sudo dmesg -C
+          make remove
 

--- a/tests/DHCP_Snooping.py
+++ b/tests/DHCP_Snooping.py
@@ -1,0 +1,48 @@
+from scapy.all import *
+
+def update_DHCP(interface,servers_ip_address,clients_new_ip_address,clients_mac_address):
+
+    # Define the client MAC address
+    client_mac = clients_mac_address  # Replace with actual client MAC
+
+    # Construct DHCP ACK packet
+    dhcp_ack = (
+        Ether(src="00:11:22:33:44:55", dst=client_mac) /  # Server MAC to Client MAC
+        IP(src=servers_ip_address, dst="255.255.255.255") /  # Server IP
+        UDP(sport=67, dport=68) /  # DHCP Server-to-Client ports
+        BOOTP(
+            op=2,  # Reply (2 = BOOTREPLY)
+            yiaddr=clients_new_ip_address,  # Assigned IP
+            siaddr=servers_ip_address,  # DHCP Server IP
+            chaddr=bytes.fromhex(client_mac.replace(":", ""))  # Client MAC in bytes
+        ) /
+        DHCP(options=[
+            ("message-type", "ack"),
+            ("server_id", servers_ip_address),  # DHCP Server IP
+            ("subnet_mask", "255.255.255.0"),
+            ("router", servers_ip_address),  # Default Gateway
+            ("lease_time", 3600),  # Lease time in seconds
+            "end"
+        ])
+    )
+
+    # Send the packet
+    sendp(dhcp_ack, iface="veth0", verbose=True)  # Replace "eth0" with your actual network interface
+
+def dhcp_handling():
+    interface = "veth0"
+    servers_ip_address="192.168.1.100"
+    clients_new_ip_address="192.168.1.1"
+    clients_mac_address="e2:c8:14:a6:4f:ed"
+    update_DHCP(interface,servers_ip_address,clients_new_ip_address,clients_mac_address)
+
+    interface = "veth3"
+    servers_ip_address="192.168.1.100"
+    clients_new_ip_address="192.168.1.2"
+    clients_mac_address="3a:18:70:ca:91:b2"
+    update_DHCP(interface,servers_ip_address,clients_new_ip_address,clients_mac_address)
+
+
+if __name__ == "__main__":
+    dhcp_handling()
+  


### PR DESCRIPTION
Introduced a test case to verify that Dynamic ARP Inspection (DAI) allows communication when a DHCP ACK is observed for a given IP. This test confirms that ARP packets are only accepted when the DHCP Snooping table is updated and acknowledges the sources.
