### PR TITLE
DAIR feature: Trusted and Untrusted Interfaces List Management

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ KERNELRELEASE := $(shell uname -r)
 KDIR := /lib/modules/${KERNELRELEASE}/build
 MDIR := /lib/modules/${KERNELRELEASE}
 obj-m := ${MODULE}.o
-${MODULE}-objs := main.o dhcp.o
+${MODULE}-objs := main.o dhcp.o trustedInterfaces.o
 
 all:
 	make -C ${KDIR} M=${PWD} modules

--- a/main.c
+++ b/main.c
@@ -1,5 +1,6 @@
 
 #include "dhcp.h"
+#include "trustedInterfaces.h"
 #include "errno.h"
 
 #include <linux/netfilter_bridge.h>
@@ -71,6 +72,8 @@ static unsigned int arp_hook(void* priv, struct sk_buff* skb, const struct nf_ho
         // Drop if skb is NULL
         return NF_DROP;  
     }
+
+    print_trusted_interface_list();
 
     if(strcmp(dev->name,"enp0s7")==0){
         //printk(KERN_INFO "kdai: Matched ma1\n");
@@ -313,6 +316,18 @@ static int arp_is_valid(struct sk_buff* skb, u16 ar_op, unsigned char* sha,
 
 
 static int __init kdai_init(void) {
+    
+    //populate_trusted_interface_list();
+    //insert_trusted_interface("enp0s4");
+    print_trusted_interface_list();
+
+    if(find_trusted_interface("enp0s4")) {
+        printk(KERN_INFO "Found enp0s4 in the list");
+    } else {
+        printk(KERN_INFO "Did not find enp0s4 in the list");
+    }
+
+
     /* Initialize arp netfilter hook */
     arpho = (struct nf_hook_ops *) kcalloc(1, sizeof(struct nf_hook_ops), GFP_KERNEL);
     if (unlikely(!arpho))
@@ -373,6 +388,8 @@ static void __exit kdai_exit(void) {
     kfree(ipho);
     clean_dhcp_snooping_table();
     kthread_stop(dhcp_thread);
+    free_trusted_interface_list();
+
 }
 
 module_init(kdai_init);

--- a/trustedInterfaces.c
+++ b/trustedInterfaces.c
@@ -4,61 +4,77 @@
 LIST_HEAD(trusted_interface_list);  // Global list head for interfaces
 static int trusted_list_size = 0;
 
-// Function to populate the list with all interfaces as trusted
+/**
+ * populate_trusted_interface_list - Populate the trusted interface list with all network interfaces.asm
+ * 
+ * This function iterates over all netowrk interfaces in the system and inserts each one into the
+ * the trusted interface list.
+ * 
+ */
 void populate_trusted_interface_list(void) {
     struct net_device *dev;
-    
     // Iterate over all network interfaces
     for_each_netdev(&init_net, dev) {
-        struct interface_entry *new_entry;
-
-        // Allocate memory for new entry, using kmalloc, the kernel equivalent of malloc
-        // GFP_KERNEL allows for blocking. Default for most kernel allocaitons
-        new_entry = kmalloc(sizeof(struct interface_entry), GFP_KERNEL);
-
-        //If memmory could not be allocated return
-        if (!new_entry) {
-            printk(KERN_ERR "kdai: Memory allocation failed for interface entry\n");
-            return;
-        }
-
-        // Copy interface name and add to list
-        strncpy(new_entry->name, dev->name, IFNAMSIZ - 1);
-        new_entry->name[IFNAMSIZ - 1] = '\0';  // Ensure null termination
-        list_add_tail(&new_entry->list, &trusted_interface_list);
-        trusted_list_size++;
+        insert_trusted_interface(dev->name);
     }
 }
 
-void insert_trusted_interface(const char *device_name) {
+/**
+ * insert_trusted_interface - Insert a new interface into the trusted list.
+ * @device_name: The name of the trusted interface to insert
+ * 
+ * This fucntion inserts the name of a network interface into teh trusted interface list. 
+ * It first checks if the interface already exists in the list using find_trusted_interface. 
+ * If the interface is not found it alloactes memory for a new entry, and cpoies the device name. 
+ * The list field is the intialized for the new entry and this fucntion adds the new entry to
+ * the end fo the lis tusing list_add_tail. The trusted_list_size if then incremented, and 
+ * a message is printed to indicate the enw addition.asm
+ * 
+ * Return: This fucntion returns 1 if the interface name was added, 0 if it already exists,
+ * and -1 if mmory allocaiton failed
+ */
+int insert_trusted_interface(const char *device_name) {
 
     struct interface_entry *new_entry;
 
     //If we found that device already return
     if(find_trusted_interface(device_name)){
-        return;
+        return 0;
     }
 
     // Allocate memory for the new entry
     new_entry = kmalloc(sizeof(struct interface_entry), GFP_KERNEL);
     if (!new_entry) {
         printk(KERN_ERR "Failed to allocate memory for interface entry\n");
-        return;
+        return -1;
     }
 
     // Copy the device name safely
     strncpy(new_entry->name, device_name, IFNAMSIZ - 1);
     new_entry->name[IFNAMSIZ - 1] = '\0'; // Ensure null termination
 
+    // Initialize the list field of the new entry
+    INIT_LIST_HEAD(&new_entry->list);
+
     // Add to the end of the list
     list_add_tail(&new_entry->list, &trusted_interface_list);
     trusted_list_size++;
 
     printk(KERN_INFO "Added interface: %s\n", new_entry->name);
+
+    return 1;
 }
 
-//Function to find an interface in the trusted list. Will return the device if the interface is trusted.
-//Will return NULL if the device was not found
+/**
+ * find_trusted_interface - Find an interface in the trusted list.
+ * @interface_name: The name of the interaface to find
+ * 
+ * This function searches the trusted interface list for an entry that matches the given interface name.
+ * If a matching entry is found, the function returns the name of th einterface. If no match is found the
+ * function returns NULL.
+ * 
+ * Return: The name of the trusted interface if found, or NULL if not found.
+ */
 const char* find_trusted_interface(const char *interface_name) {
     struct interface_entry *entry;
 
@@ -72,26 +88,46 @@ const char* find_trusted_interface(const char *interface_name) {
     return NULL; // Interface not found, return NULL
 }
 
-// Function to print all interfaces in the list
+/**
+ * print_trusted_interface_list - Print all interfaces in the trusted list
+ * 
+ * This function prints the names of all network interfaces in the trusted interface list.
+ * If the list is empty, it prints a message indicaitng that all interfaces are assumed to be Untrusted.
+ * 
+ * Return: This function does not return a value
+ */
 void print_trusted_interface_list(void) {
     struct interface_entry *entry;
 
     printk(KERN_INFO "kdai: List of trusted network interfaces:\n");
 
+    //If the list is empty notify the user
     if(trusted_list_size == 0) {
         printk(KERN_INFO "!!(The list is currently empty) All interfaces are assumed Untrusted!!\n");
         return;
     }
 
+    //Iterate and print each entry
     list_for_each_entry(entry, &trusted_interface_list, list) {
         printk(KERN_INFO " - %s\n", entry->name);
     }
 }
 
-// Function to free the list during module cleanup
+/**
+ * free_trusted_interface_list - Free all entries in the trusted interface list
+ * 
+ * This function iterates through the trusted interface list and frees each entry.
+ * It uses list_for_each_entry_safe to  traverse the list while deleting entries. 
+ * This means it uses an additional temporary pointer to store the next entry before 
+ * deleting the currnet one Each entry is removed from the list using list_del and 
+ * then freed using kfree.
+ * 
+ * Return: this function does not return anything
+ */
 void free_trusted_interface_list(void) {
     struct interface_entry *entry, *tmp;
 
+    //Iterate through the list, del and free each entry.
     list_for_each_entry_safe(entry, tmp, &trusted_interface_list, list) {
         list_del(&entry->list);
         kfree(entry);

--- a/trustedInterfaces.c
+++ b/trustedInterfaces.c
@@ -1,0 +1,100 @@
+#include "trustedInterfaces.h"
+#include "errno.h"
+
+LIST_HEAD(trusted_interface_list);  // Global list head for interfaces
+static int trusted_list_size = 0;
+
+// Function to populate the list with all interfaces as trusted
+void populate_trusted_interface_list(void) {
+    struct net_device *dev;
+    
+    // Iterate over all network interfaces
+    for_each_netdev(&init_net, dev) {
+        struct interface_entry *new_entry;
+
+        // Allocate memory for new entry, using kmalloc, the kernel equivalent of malloc
+        // GFP_KERNEL allows for blocking. Default for most kernel allocaitons
+        new_entry = kmalloc(sizeof(struct interface_entry), GFP_KERNEL);
+
+        //If memmory could not be allocated return
+        if (!new_entry) {
+            printk(KERN_ERR "kdai: Memory allocation failed for interface entry\n");
+            return;
+        }
+
+        // Copy interface name and add to list
+        strncpy(new_entry->name, dev->name, IFNAMSIZ - 1);
+        new_entry->name[IFNAMSIZ - 1] = '\0';  // Ensure null termination
+        list_add_tail(&new_entry->list, &trusted_interface_list);
+        trusted_list_size++;
+    }
+}
+
+void insert_trusted_interface(const char *device_name) {
+
+    struct interface_entry *new_entry;
+
+    //If we found that device already return
+    if(find_trusted_interface(device_name)){
+        return;
+    }
+
+    // Allocate memory for the new entry
+    new_entry = kmalloc(sizeof(struct interface_entry), GFP_KERNEL);
+    if (!new_entry) {
+        printk(KERN_ERR "Failed to allocate memory for interface entry\n");
+        return;
+    }
+
+    // Copy the device name safely
+    strncpy(new_entry->name, device_name, IFNAMSIZ - 1);
+    new_entry->name[IFNAMSIZ - 1] = '\0'; // Ensure null termination
+
+    // Add to the end of the list
+    list_add_tail(&new_entry->list, &trusted_interface_list);
+    trusted_list_size++;
+
+    printk(KERN_INFO "Added interface: %s\n", new_entry->name);
+}
+
+//Function to find an interface in the trusted list. Will return the device if the interface is trusted.
+//Will return NULL if the device was not found
+const char* find_trusted_interface(const char *interface_name) {
+    struct interface_entry *entry;
+
+    // Loop through the list to find a matching interface name
+    list_for_each_entry(entry, &trusted_interface_list, list) {
+        if (strncmp(entry->name, interface_name, IFNAMSIZ) == 0) {
+            return entry->name; // Interface found, return interface
+        }
+    }
+
+    return NULL; // Interface not found, return NULL
+}
+
+// Function to print all interfaces in the list
+void print_trusted_interface_list(void) {
+    struct interface_entry *entry;
+
+    printk(KERN_INFO "kdai: List of trusted network interfaces:\n");
+
+    if(trusted_list_size == 0) {
+        printk(KERN_INFO "!!(The list is currently empty) All interfaces are assumed Untrusted!!\n");
+        return;
+    }
+
+    list_for_each_entry(entry, &trusted_interface_list, list) {
+        printk(KERN_INFO " - %s\n", entry->name);
+    }
+}
+
+// Function to free the list during module cleanup
+void free_trusted_interface_list(void) {
+    struct interface_entry *entry, *tmp;
+
+    list_for_each_entry_safe(entry, tmp, &trusted_interface_list, list) {
+        list_del(&entry->list);
+        kfree(entry);
+    }
+}
+

--- a/trustedInterfaces.h
+++ b/trustedInterfaces.h
@@ -1,16 +1,20 @@
 #include "common.h"
 
-// Structure for storing interface names
+// Structure for storing trusted interface names
 struct interface_entry {
-    char name[IFNAMSIZ];    // Store interface name, IFNAMSIZ is a constant in the linux kernel
+    char name[IFNAMSIZ];    // Store trusted interface name
+                            // IFNAMSIZ is a constant in the linux kernel
                             // that defines the maximum length of a network interface
-                        
-    struct list_head list;  // Linked list pointer
+    struct list_head list;  // Point to the next item in the linked list 
 };
 
 // Function declarations
 void populate_trusted_interface_list(void);
-void insert_trusted_interface(const char *device_name);
+
+int insert_trusted_interface(const char *device_name);
+
 const char* find_trusted_interface(const char *interface_name);
+
 void print_trusted_interface_list(void);
+
 void free_trusted_interface_list(void);

--- a/trustedInterfaces.h
+++ b/trustedInterfaces.h
@@ -1,0 +1,16 @@
+#include "common.h"
+
+// Structure for storing interface names
+struct interface_entry {
+    char name[IFNAMSIZ];    // Store interface name, IFNAMSIZ is a constant in the linux kernel
+                            // that defines the maximum length of a network interface
+                        
+    struct list_head list;  // Linked list pointer
+};
+
+// Function declarations
+void populate_trusted_interface_list(void);
+void insert_trusted_interface(const char *device_name);
+const char* find_trusted_interface(const char *interface_name);
+void print_trusted_interface_list(void);
+void free_trusted_interface_list(void);


### PR DESCRIPTION
Added functionality that allows the management of a list for trusted network interfaces by name. Implemented functions like insert_trusted_interface() to add interfaces to a trusted list and added find_trusted_interface() to check if an interface exists in the list. This feature is intended to be combined with another feature DAI rate limiting in future commits to enforce rate limiting on untrusted interfaces. Minor changes were also made to main.c to comply with C90 variable declaration rules.
