### PR TITLE
Switch Rate Limiting from Static Maximum Interfaces to Dynamic Memory Allocation

### DIFF
--- a/rate_limit.h
+++ b/rate_limit.h
@@ -1,5 +1,13 @@
 #include "common.h"
 
+struct rate_limit_entry {
+    char iface_name[IFNAMSIZ];  // Store the interface name
+    unsigned int packet_count;  // Count of packets received
+    unsigned long last_packet_time;  // Time of the last packet received
+    struct list_head list;
+
+};
+
 // Function declarations
 bool rate_limit_reached(struct  sk_buff* skb);
 void clean_rate_limit_table(void);


### PR DESCRIPTION
Each rate limit entry is now created at runtime using kmalloc and inserted into a global list instead of requiring a maximum interface count for memory allocation. This change is meant to enhance scalability and decrease the configuration dependency requirements.