### PR TITLE
Add Feature: Dynamic ARP Inspection Per VLAN and Related Test Scripts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ KERNELRELEASE := $(shell uname -r)
 KDIR := /lib/modules/${KERNELRELEASE}/build
 MDIR := /lib/modules/${KERNELRELEASE}
 obj-m := ${MODULE}.o
-${MODULE}-objs := main.o dhcp.o trustedInterfaces.o rate_limit.o
+${MODULE}-objs := main.o dhcp.o trustedInterfaces.o rate_limit.o vlan.o
 
 all:
 	make -C ${KDIR} M=${PWD} modules

--- a/dhcp.h
+++ b/dhcp.h
@@ -54,6 +54,7 @@ struct dhcp_snooping_entry {
     u8 mac[ETH_ALEN];
     u32 lease_time;
     u32 expires;
+    u16 vlan_id;
     struct list_head list;
 };
 
@@ -61,11 +62,11 @@ extern struct task_struct* dhcp_thread;
 
 int dhcp_is_valid(struct sk_buff* skb);
 
-void insert_dhcp_snooping_entry(u8* mac, u32 ip, u32 lease_time, u32 expire_time);
+void insert_dhcp_snooping_entry(u8* mac, u32 ip, u32 lease_time, u32 expire_time, u16 vlan_id);
 
-struct dhcp_snooping_entry* find_dhcp_snooping_entry(u32 ip);
+struct dhcp_snooping_entry* find_dhcp_snooping_entry(u32 ip, u16 vlan_id);
 
-void delete_dhcp_snooping_entry(u32 ip);
+void delete_dhcp_snooping_entry(u32 ip, u16 vlan_id);
 
 void clean_dhcp_snooping_table(void);
 

--- a/main.c
+++ b/main.c
@@ -256,10 +256,12 @@ static unsigned int bridge_hook(void* priv, struct sk_buff* skb, const struct nf
             //YES
             //Set packet VLAN_id to 0
             vlan_id = 0;
-            printk(KERN_INFO "kdai: globally_enabled_DAI was ENABLED");
+            printk(KERN_INFO "kdai: globally_enabled_DAI was ENABLED\n");
             //Continue checking
         } else {
             //NO
+            printk(KERN_INFO "kdai: globally_enabled_DAI was DISABLED\n");
+
             //Does it have a VLAN?
             if (skb_vlan_tag_present(skb)) {
                 //YES
@@ -269,12 +271,12 @@ static unsigned int bridge_hook(void* priv, struct sk_buff* skb, const struct nf
             } else {
                 //NO
                 //Global was disabled and VLAN_id was not found, accept packet
-                printk(KERN_INFO "kdai: vlan_id was NOT in the packet ACCEPTING\n\n");
+                printk(KERN_INFO "kdai: vlan_id was NOT in the PACKET. ACCEPTING\n\n");
                 return NF_ACCEPT;
             }
             //Continue checking
         }
-        printk(KERN_INFO "kdai: vlan_id is: %u", vlan_id);
+        printk(KERN_INFO "kdai: vlan_id is: %u\n", vlan_id);
 
         //3rd Is DAI enabled for this VLAN? OR is DAI enabled for all interfaces?
         if(vlan_should_be_inspected(vlan_id) || globally_enabled_DAI) {
@@ -310,7 +312,7 @@ static unsigned int bridge_hook(void* priv, struct sk_buff* skb, const struct nf
         } else {
             //NO
             //No need to Inspect packet it was not in our list of VLANS to Inspect
-            printk(KERN_INFO "kdai: vlan_id was NOT in the hash table. ACCEPTING\n\n");
+            printk(KERN_INFO "kdai: vlan_id was NOT in the HASH TABLE. ACCEPTING\n\n");
             return NF_ACCEPT;
         }
     } else {
@@ -442,7 +444,7 @@ static unsigned int ip_hook(void* priv, struct sk_buff* skb, const struct nf_hoo
 
 static int __init kdai_init(void) {
     
-    globally_enabled_DAI = true;
+    globally_enabled_DAI = false;
     //insert_trusted_interface("enp0s4", 0);
     //insert_trusted_interface("enp0s6", 0);
     print_trusted_interface_list();

--- a/rate_limit.c
+++ b/rate_limit.c
@@ -66,7 +66,7 @@ static struct rate_limit_entry* create_rate_limit_entry(const char *iface_name, 
     //Populate the new entry
     strscpy(entry->iface_name, iface_name, IFNAMSIZ);
     entry->packet_count = 0;
-    entry->last_packet_time = 0;
+    entry->last_packet_time = jiffies;
     entry->vlan_id = vlan_id;
 
     //Add the new entry to our list

--- a/rate_limit.h
+++ b/rate_limit.h
@@ -1,11 +1,11 @@
 #include "common.h"
 
 struct rate_limit_entry {
-    char iface_name[IFNAMSIZ];  // Store the interface name
-    unsigned int packet_count;  // Count of packets received
-    unsigned long last_packet_time;  // Time of the last packet received
-    struct list_head list;
-
+    char iface_name[IFNAMSIZ];          // Store the interface name
+    unsigned int packet_count;          // Count of packets received
+    unsigned long last_packet_time;     // Time of the last packet received
+    u16 vlan_id;
+    struct list_head list;              
 };
 
 // Function declarations

--- a/rate_limit.h
+++ b/rate_limit.h
@@ -9,5 +9,5 @@ struct rate_limit_entry {
 };
 
 // Function declarations
-bool rate_limit_reached(struct  sk_buff* skb);
+bool rate_limit_reached(const char *interface_name, u16 vlan_id);
 void clean_rate_limit_table(void);

--- a/tests/send_ARP_Packets_VLAN10.py
+++ b/tests/send_ARP_Packets_VLAN10.py
@@ -1,0 +1,16 @@
+from scapy.all import ARP, Ether, Dot1Q, sendp
+import time
+
+# Define the VLAN ID
+vlan_id = 10
+
+# Craft the packet with the VLAN tag
+packet = Ether(dst="0c:83:01:80:00:03", src="0c:38:66:2f:00:02") / \
+         Dot1Q(vlan=vlan_id) / \
+         ARP(op=2, psrc="192.168.122.48", hwsrc="0c:38:66:2f:00:02",
+             pdst="192.168.122.110", hwdst="0c:83:01:80:00:03")
+
+# Send at a rate of 5 packets per second
+for i in range(200):
+    sendp(packet, iface="enp0s5", verbose=0)
+    time.sleep(0.2)  # 0.2s = 5 per second

--- a/tests/send_ARP_Packets_VLAN20.py
+++ b/tests/send_ARP_Packets_VLAN20.py
@@ -1,0 +1,16 @@
+from scapy.all import ARP, Ether, Dot1Q, sendp
+import time
+
+# Define the VLAN ID
+vlan_id = 20
+
+# Craft the packet with the VLAN tag
+packet = Ether(dst="0c:83:01:80:00:03", src="0c:38:66:2f:00:02") / \
+         Dot1Q(vlan=vlan_id) / \
+         ARP(op=2, psrc="192.168.122.48", hwsrc="0c:38:66:2f:00:02",
+             pdst="192.168.122.110", hwdst="0c:83:01:80:00:03")
+
+# Send at a rate of 5 packets per second
+for i in range(200):
+    sendp(packet, iface="enp0s5", verbose=0)
+    time.sleep(0.2)  # 0.2s = 5 per second

--- a/trustedInterfaces.h
+++ b/trustedInterfaces.h
@@ -5,15 +5,16 @@ struct interface_entry {
     char name[IFNAMSIZ];    // Store trusted interface name
                             // IFNAMSIZ is a constant in the linux kernel
                             // that defines the maximum length of a network interface
+    u16 vlan_id;            //The vlan associated with DAI
     struct list_head list;  // Point to the next item in the linked list 
 };
 
 // Function declarations
 void populate_trusted_interface_list(void);
 
-int insert_trusted_interface(const char *device_name);
+int insert_trusted_interface(const char *device_name, u16 vlan_id);
 
-const char* find_trusted_interface(const char *interface_name);
+const char* find_trusted_interface(const char *interface_name, u16 vlan_id);
 
 void print_trusted_interface_list(void);
 

--- a/vlan.c
+++ b/vlan.c
@@ -8,12 +8,12 @@
 static struct hlist_head vlan_hash_table[VLAN_HASH_SIZE];
 
 // Hash function
-static inline unsigned int vlan_hash(unsigned int vlan_id) {
+static inline unsigned int vlan_hash(u16 vlan_id) {
     return hash_32(vlan_id, VLAN_HASH_SIZE);
 }
 
 // Add VLAN to be inspected
-void add_vlan_to_inspect(unsigned int vlan_id) {
+void add_vlan_to_inspect(u16 vlan_id) {
     unsigned int hash = vlan_hash(vlan_id);
     struct vlan_hash_entry *entry = kmalloc(sizeof(struct vlan_hash_entry), GFP_KERNEL);
     if (!entry)
@@ -24,7 +24,7 @@ void add_vlan_to_inspect(unsigned int vlan_id) {
 }
 
 // Check if VLAN should be inspected
-bool vlan_should_be_inspected(unsigned int vlan_id) {
+bool vlan_should_be_inspected(u16 vlan_id) {
     unsigned int hash = vlan_hash(vlan_id);
     struct vlan_hash_entry *entry;
 
@@ -36,7 +36,7 @@ bool vlan_should_be_inspected(unsigned int vlan_id) {
 }
 
 // To remove a VLAN
-void remove_vlan_from_inspect(unsigned int vlan_id) {
+void remove_vlan_from_inspect(u16 vlan_id) {
     unsigned int hash = vlan_hash(vlan_id);
     struct vlan_hash_entry *entry;
 

--- a/vlan.c
+++ b/vlan.c
@@ -1,0 +1,50 @@
+#include "vlan.h"
+#include <linux/kernel.h>
+#include <linux/hash.h>
+#include <linux/slab.h>
+
+#define VLAN_HASH_SIZE 256  // Choose a reasonable size for your needs
+
+static struct hlist_head vlan_hash_table[VLAN_HASH_SIZE];
+
+// Hash function
+static inline unsigned int vlan_hash(unsigned int vlan_id) {
+    return hash_32(vlan_id, VLAN_HASH_SIZE);
+}
+
+// Add VLAN to be inspected
+void add_vlan_to_inspect(unsigned int vlan_id) {
+    unsigned int hash = vlan_hash(vlan_id);
+    struct vlan_hash_entry *entry = kmalloc(sizeof(struct vlan_hash_entry), GFP_KERNEL);
+    if (!entry)
+        return;
+
+    entry->vlan_id = vlan_id;
+    hlist_add_head(&entry->node, &vlan_hash_table[hash]);
+}
+
+// Check if VLAN should be inspected
+bool vlan_should_be_inspected(unsigned int vlan_id) {
+    unsigned int hash = vlan_hash(vlan_id);
+    struct vlan_hash_entry *entry;
+
+    hlist_for_each_entry(entry, &vlan_hash_table[hash], node) {
+        if (entry->vlan_id == vlan_id)
+            return true;
+    }
+    return false;
+}
+
+// To remove a VLAN
+void remove_vlan_from_inspect(unsigned int vlan_id) {
+    unsigned int hash = vlan_hash(vlan_id);
+    struct vlan_hash_entry *entry;
+
+    hlist_for_each_entry(entry, &vlan_hash_table[hash], node) {
+        if (entry->vlan_id == vlan_id) {
+            hlist_del(&entry->node);
+            kfree(entry);
+            return;
+        }
+    }
+}

--- a/vlan.h
+++ b/vlan.h
@@ -1,12 +1,12 @@
 #include "common.h"
 
 struct vlan_hash_entry {
-    unsigned int vlan_id;
+    u16 vlan_id;
     struct hlist_node node;
 };
 
-void add_vlan_to_inspect(unsigned int vlan_id);
+void add_vlan_to_inspect(u16 vlan_id);
 
-bool vlan_should_be_inspected(unsigned int vlan_id);
+bool vlan_should_be_inspected(u16 vlan_id);
 
-void remove_vlan_from_inspect(unsigned int vlan_id);
+void remove_vlan_from_inspect(u16 vlan_id);

--- a/vlan.h
+++ b/vlan.h
@@ -1,0 +1,12 @@
+#include "common.h"
+
+struct vlan_hash_entry {
+    unsigned int vlan_id;
+    struct hlist_node node;
+};
+
+void add_vlan_to_inspect(unsigned int vlan_id);
+
+bool vlan_should_be_inspected(unsigned int vlan_id);
+
+void remove_vlan_from_inspect(unsigned int vlan_id);


### PR DESCRIPTION
This PR introduces support for Dynamic ARP Inspection (DAI) on a per-VLAN basis, with the option to enable global inspection mode. This ensures DAI decisions are scoped to specific VLAN contexts unless explicitly overridden to be for all incoming packets.

Features & Changes
- Packets are only inspected if their VLAN ID is in the configured list (vlan_should_be_inspected). This list can be controlled by administrators
- DHCP snooping entries now include VLAN ID and are matched against both IP and VLAN.
- Trusted interfaces are also now tracked per VLAN (find_trusted_interface now takes VLAN ID).
- Rate limiting is scoped per-interface and now per-VLAN as well

Global Inspection Mode (globally_enabled_DAI)
- When enabled, all ARP packets are inspected regardless of VLAN tagging or VLAN existence. Packets are assigned a default vlan_id = 0, and all DAI logic is executed using this ID.
