### PR TITLE
Add Feature: Dynamic ARP inspection per VLAN

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ KERNELRELEASE := $(shell uname -r)
 KDIR := /lib/modules/${KERNELRELEASE}/build
 MDIR := /lib/modules/${KERNELRELEASE}
 obj-m := ${MODULE}.o
-${MODULE}-objs := main.o dhcp.o trustedInterfaces.o rate_limit.o
+${MODULE}-objs := main.o dhcp.o trustedInterfaces.o rate_limit.o vlan.o
 
 all:
 	make -C ${KDIR} M=${PWD} modules

--- a/dhcp.h
+++ b/dhcp.h
@@ -54,6 +54,7 @@ struct dhcp_snooping_entry {
     u8 mac[ETH_ALEN];
     u32 lease_time;
     u32 expires;
+    u16 vlan_id;
     struct list_head list;
 };
 
@@ -61,11 +62,11 @@ extern struct task_struct* dhcp_thread;
 
 int dhcp_is_valid(struct sk_buff* skb);
 
-void insert_dhcp_snooping_entry(u8* mac, u32 ip, u32 lease_time, u32 expire_time);
+void insert_dhcp_snooping_entry(u8* mac, u32 ip, u32 lease_time, u32 expire_time, u16 vlan_id);
 
-struct dhcp_snooping_entry* find_dhcp_snooping_entry(u32 ip);
+struct dhcp_snooping_entry* find_dhcp_snooping_entry(u32 ip, u16 vlan_id);
 
-void delete_dhcp_snooping_entry(u32 ip);
+void delete_dhcp_snooping_entry(u32 ip, u16 vlan_id);
 
 void clean_dhcp_snooping_table(void);
 

--- a/main.c
+++ b/main.c
@@ -2,8 +2,11 @@
 #include "dhcp.h"
 #include "trustedInterfaces.h"
 #include "rate_limit.h"
+#include "vlan.h"
 #include "errno.h"
 #include <linux/netfilter_bridge.h>
+#include <linux/if_vlan.h>  // For VLAN related operations
+
 
 MODULE_LICENSE("GPL");
 MODULE_AUTHOR("M. Sami GURPINAR <sami.gurpinar@gmail.com>. Edited by Korel Ucpinar <korelucpinar@gmail.com>");
@@ -14,6 +17,9 @@ MODULE_VERSION("0.1");
 
 static struct nf_hook_ops* ipho = NULL;
 static struct nf_hook_ops* brho = NULL;
+bool globally_enabled_DAI;
+bool static_ACL_Enabled;
+
 
 static int arp_is_valid(struct sk_buff* skb, u16 ar_op, unsigned char* sha, 
     u32 sip, unsigned char* tha, u32 tip)  {
@@ -72,15 +78,7 @@ static int arp_is_valid(struct sk_buff* skb, u16 ar_op, unsigned char* sha,
     return status;
 }
 
-static void print_status(int status){
-    if(status == 1){
-        printk(KERN_INFO "kdai: -- ARP RETURN status was: NF_ACCEPT -- \n\n");
-    } else {
-        printk(KERN_INFO "kdai: -- ARP RETURN status was: NF_DROP -- \n\n");
-    }
-}
-
-static unsigned int validate_arp_request(void* priv, struct sk_buff* skb, const struct nf_hook_state* state) {
+static unsigned int validate_arp_request(void* priv, struct sk_buff* skb, const struct nf_hook_state* state, u16 vlan_id) {
     
     //Refrence Structure to Standard ARP header used in the linux Kernel
     struct arp_hdr {
@@ -96,7 +94,6 @@ static unsigned int validate_arp_request(void* priv, struct sk_buff* skb, const 
     };
 
     struct neighbour* hw;
-    int static_ACL_Enabled;
     struct dhcp_snooping_entry* entry;
     struct ethhdr *eth;
     struct arp_hdr *arp;
@@ -105,15 +102,7 @@ static unsigned int validate_arp_request(void* priv, struct sk_buff* skb, const 
     unsigned char *tha;
     u32 tip;
     struct net_device *dev;
-    unsigned int status = NF_ACCEPT;
-
-
     eth = eth_hdr(skb);  // Extract the Ethernet header
-    if (ntohs(eth->h_proto) != ETH_P_ARP) {
-        // Not an ARP packet
-        printk(KERN_INFO "kdai: Packet was NOT an ARP packet. DAI does nothing. Accepting\n");
-        return NF_ACCEPT;
-    }
     arp = (struct arp_hdr *)(eth + 1);  // Skip past the Ethernet header to get the ARP header
     
     sha = arp->ar_sha;   // Sender MAC address
@@ -123,14 +112,9 @@ static unsigned int validate_arp_request(void* priv, struct sk_buff* skb, const 
 
     dev = skb->dev;
 
-    if (unlikely(!skb)) {
-        // Drop if skb is NULL
-        return NF_DROP;  
-    }
-
     //For debugging purpouses only
     if(strcmp(dev->name,"enp0s7")==0){
-        printk(KERN_INFO "kdai: Packet was ARP packet for enp0s7. DAI does nothing. Accepting\n");
+        printk(KERN_INFO "kdai: DEBUGING ONLY Packet was ARP packet for enp0s7. DAI does nothing. ACCEPTING\n\n");
         return NF_ACCEPT;
     } else {
         printk(KERN_ERR "kdai: -- Hooked ARP Packet --\n");
@@ -141,9 +125,9 @@ static unsigned int validate_arp_request(void* priv, struct sk_buff* skb, const 
         printk(KERN_INFO "kdai: ARP was VALID\n");
     } else {
         printk(KERN_INFO "kdai: ARP was NOT VALID\n");
-        status = NF_DROP;
-        print_status(status);
-        return status;
+        printk(KERN_INFO "kdai: DROPPING\n\n");
+        return NF_DROP;
+
     }
 
     printk(KERN_INFO "kdai: ARP request from Source IP: %pI4, came on Interface Name: %s\n", &sip, dev->name);
@@ -159,72 +143,59 @@ static unsigned int validate_arp_request(void* priv, struct sk_buff* skb, const 
     } else {
         printk(KERN_INFO "kdai: NO entry exists in the ARP Snooping Table for the claimed source IP address.\n");
     }
-
     // If we find an entry in the arp table for the source IP address
     // AND the Mac Address of that entry is the same as the mac address from the ARP packet
     if (hw && memcmp(hw->ha, sha, dev->addr_len) == 0) {
-        printk(KERN_INFO "kdai: A Known Mac Adress with the same Source IP was the same as the received Mac Address\n");
         //If they are the same accept the packet
-        status = NF_ACCEPT;
         neigh_release(hw);
-        print_status(status);
-        return status;
+        printk(KERN_INFO "kdai: A Known Mac Adress with the same Source IP was the same as the received Mac Address\n");
+        printk(KERN_INFO "kdai: ACCEPTING\n\n");
+        return NF_ACCEPT;
     }  
 
     //The entries were different from expected. If Static ACL is configured do not Check DHCP table.
-    
-    static_ACL_Enabled = 0; // Default is false
     if (static_ACL_Enabled){
         //Accept packets only that were statically configured
         //Since the previous check failed drop the packet
         printk(KERN_INFO "kdai: Implicit Drop was Added since static_ACL was Enabled\n");
-        status = NF_DROP;
-        print_status(status);
-        return status;
+        printk(KERN_INFO "kdai: DROPPING\n\n");
+        return NF_DROP;
     }
     
     //If an exisitng entry in the ARP table did not match. Check dynamic DHCP Configuraiton
-
+    /* This is ARP DHCP Snooping! */
     // Query the dhcp snooping table
     // Look up the DHCP Snooping Table to check if there is an entry for the claimed
     // source IP address in the table.
-    entry = find_dhcp_snooping_entry(sip);
+    entry = find_dhcp_snooping_entry(sip, vlan_id);
     if(entry) {
         printk(KERN_INFO "kdai: An entry exists in the DHCP Snooping Table for the claimed source IP address.\n");
     } else {
         printk(KERN_INFO "kdai: NO entry exists in the DHCP Snooping Table for the claimed source IP address.\n");
         printk(KERN_INFO "kdai: It is not possible to Validate Source.\n");
-        status = NF_DROP;
-        print_status(status);
-        return status;
+        printk(KERN_INFO "kdai: DROPPING\n\n");
+        return NF_DROP;
     }
-
     //If we find an entry AND the Mac Address from the DHCP snooping table does not match
     // with the MAC address in the ARP packet ARP spoofing detected.
     if (entry && memcmp(entry->mac, sha, ETH_ALEN) != 0) {
         printk(KERN_INFO "kdai: ARP spoofing detected on %s from %pM\n", dev->name, sha);
-        printk(KERN_INFO "ARP spoofing detected on %s, packet droped", dev->name);
-        status = NF_DROP;
-        print_status(status);
-        return status;
+        printk(KERN_INFO "ARP spoofing detected on %s, packet droped\n", dev->name);
+        printk(KERN_INFO "kdai: DROPPING\n\n");
+        return NF_DROP;
     } else {
         //The DHCP Snooping table matched.
         printk(KERN_INFO "kdai: -- ACCEPTING ARP PACKET -- \n");
-        status = NF_ACCEPT;
-        print_status(status);
-        return status;
+        printk(KERN_INFO "kdai: The DHCP Snooping table matched.\n");
+        printk(KERN_INFO "kdai: ACCEPTING\n\n");
+        return NF_ACCEPT;
     }    
 
-    print_status(status);
-    return status;
 }
 
-static bool is_trusted(struct sk_buff* skb) {
-    struct net_device *dev;
-    dev = skb->dev;
-
+static bool is_trusted(const char *interface_name, u16 vlan_id) {
     // Check if the device is trusted using the find_trusted_interface function
-    if (find_trusted_interface(dev->name)) {
+    if (find_trusted_interface(interface_name, vlan_id)) {
         //printk(KERN_INFO "\nkdai: Packet was on a trusted interface: %s!!", dev->name);
         return true;  // If the device is trusted, accept the packet
     } else {
@@ -234,40 +205,108 @@ static bool is_trusted(struct sk_buff* skb) {
 }
 
 static unsigned int bridge_hook(void* priv, struct sk_buff* skb, const struct nf_hook_state* state) {
+
+    if (unlikely(!skb)) {
+        // Drop if skb is NULL
+        printk(KERN_INFO "kdai: SKB was null");
+        printk(KERN_INFO "kdai: DROPPING\n\n");
+        return NF_DROP;  
+    }
+
     struct net_device *dev;
+    struct ethhdr * eth;
     dev = skb->dev;
+    eth = eth_hdr(skb);
+    u16 vlan_id;
 
     //Used only for debugging purpouses
     if(strcmp(dev->name,"enp0s7")==0 || strcmp(dev->name,"ma1")==0 ){
         return NF_ACCEPT;
     }
 
-    //If the interface is trusted skip any calculations and accept the packet
-    if(is_trusted(skb)){
-        return NF_ACCEPT;
-    } else {
-        //Else the interface is not trusted
-        //Ensure it is is an ARP packet before performing rate limiting
-        struct ethhdr * eth = eth_hdr(skb);
-        if(ntohs(eth->h_proto) == ETH_P_ARP){
-            printk(KERN_INFO "kdai: Recieved ARP on %s\n", dev->name);
-            printk(KERN_INFO "kdai: Checking if we hit the rate limit for %s!!\n", dev->name);
-            //If the untrusted interface has hit its rate limit, the packet should be dropped
-            if(rate_limit_reached(skb)) {
-                printk(KERN_INFO "kdai: Packet hit the rate limit...dropping!!\n");
-                return NF_DROP;
+    //1st Did we receive an ARP packet?
+    if(ntohs(eth->h_proto) == ETH_P_ARP){
+        //YES
+        printk(KERN_INFO "kdai: Recieved ARP on %s\n", dev->name);
+
+        //2nd Is Global Inspection enabled
+        if(globally_enabled_DAI) {
+            //YES
+            //Set packet VLAN_id to 0
+            vlan_id = 0;
+            printk(KERN_INFO "kdai: globally_enabled_DAI was ENABLED\n");
+            //Continue checking
+        } else {
+            //NO
+            printk(KERN_INFO "kdai: globally_enabled_DAI was DISABLED\n");
+
+            //Does it have a VLAN?
+            if (skb_vlan_tag_present(skb)) {
+                //YES
+                //Get VLAN ID from the packet
+                vlan_id = skb_vlan_tag_get_id(skb);; 
+                printk(KERN_INFO "kdai: vlan_id found: %u", vlan_id);
             } else {
-            //Else the interface has not hit its limit determine if the ARP request is real.
-                printk(KERN_INFO "kdai: Packet did NOT hit the rate limit!!\n");
-                printk(KERN_INFO "kdai: Validating Packet!!\n");
-                return validate_arp_request(priv, skb, state);
+                //NO
+                //Global was disabled and VLAN_id was not found, accept packet
+                // printk(KERN_INFO "kdai: vlan_id was NOT in the PACKET -> DROPPING\n");
+                // printk(KERN_INFO "kdai: DROPPING\n\n");
+                // return NF_DROP;
+                //Packets with no VLANs will be inspected.
+                printk(KERN_INFO "kdai: No VLAN was found defaulting to 0\n");
+                vlan_id = 0;
+            }
+            //Continue checking
+        }
+        printk(KERN_INFO "kdai: vlan_id is: %u\n", vlan_id);
+
+        //3rd Is DAI enabled for this VLAN? OR is DAI enabled for all interfaces?
+        if(vlan_should_be_inspected(vlan_id) || globally_enabled_DAI) {
+            //YES
+            //Print Logs
+            if(vlan_should_be_inspected(vlan_id)) printk(KERN_INFO "kdai: vlan_id WAS FOUND in the hash table. INSPECTING\n");
+            if(globally_enabled_DAI) printk(KERN_INFO "kdai: INSPECTING ALL\n");
+
+            //4th Is the interface not trusted?
+            if(is_trusted(dev->name,vlan_id) == false){
+                //YES
+                printk(KERN_INFO "kdai: Interface is UNTRUSTED\n");
+
+                //5th Are we under the rate limit?
+                if(!rate_limit_reached(dev->name, vlan_id)) {
+                    //YES 
+                    //The interface has not hit its limit determine if the ARP request is real.
+                    printk(KERN_INFO "kdai: Packet did NOT hit the rate limit!!\n");
+                    printk(KERN_INFO "kdai: Validating Packet!!\n");
+
+                    return validate_arp_request(priv, skb, state, vlan_id);
+
+                } else {
+                    //NO
+                    printk(KERN_INFO "kdai: Packet hit the rate limit.\n");
+                    printk(KERN_INFO "kdai: DROPPING\n\n");
+                    return NF_DROP;
+                }
+            } else {
+                //NO
+                printk(KERN_INFO "kdai: The Interface was Trusted -> ACCEPTING\n");
+                printk(KERN_INFO "kdai: ACCEPTING\n\n");
+                return NF_ACCEPT;
             }
         } else {
-            //Do nothing Accept the packet it was not arp
-            //printk(KERN_INFO "kdai: Accept Packet it was not ARP!!\n");
+            //NO
+            //No need to Inspect packet it was not in our list of VLANS to Inspect
+            printk(KERN_INFO "kdai: vlan_id was NOT in the HASH TABLE -> ACCEPTING\n");
+            printk(KERN_INFO "kdai: ACCEPTING\n\n");
             return NF_ACCEPT;
         }
-    }
+    } else {
+        //NO
+        //Do nothing Accept the packet it was not arp
+        printk(KERN_INFO "kdai: Packet was not ARP -> ACCEPTING\n");
+        printk(KERN_INFO "kdai: ACCEPTING\n\n");
+        return NF_ACCEPT;
+    }    
 }
 
 static unsigned int ip_hook(void* priv, struct sk_buff* skb, const struct nf_hook_state* state) {
@@ -282,13 +321,43 @@ static unsigned int ip_hook(void* priv, struct sk_buff* skb, const struct nf_hoo
         struct timespec ts;
     #endif
     struct dhcp_snooping_entry* entry;
-    unsigned int status = NF_ACCEPT;
-
-    if (unlikely(!skb))
+    if (unlikely(!skb)) {
+        printk(KERN_INFO "kdai: Skb was null\n");
+        printk(KERN_INFO "kdai: DROPPING\n\n");
         return NF_DROP;
+    }
 
+    /* Check if VLAN tag is present */
+    if (skb_vlan_tag_present(skb)) {
+        u16 vlan_id = skb_vlan_tag_get_id(skb);
+        printk(KERN_INFO "kdai: VLAN ID detected: %u\n", vlan_id);
+
+        skb_set_network_header(skb, skb_network_offset(skb));
+        skb_set_transport_header(skb, skb_network_offset(skb) + ip_hdr(skb)->ihl * 4);
+    }
+
+    __be16 encapsulated_proto = vlan_get_protocol(skb);
+    if (encapsulated_proto != htons(ETH_P_IP)) {
+        printk(KERN_INFO "kdai: Not an IPv4 packet, skipping -> ACCEPTING\n");
+        printk(KERN_INFO "kdai: ACCEPTING\n\n");
+        return NF_ACCEPT;
+    }
+
+    if (skb_transport_offset(skb) + sizeof(struct udphdr) > skb->len) {
+        printk(KERN_INFO "kdai: UDP header extends beyond packet. -> DROPPING\n");
+        printk(KERN_INFO "kdai: DROPPING\n\n");
+        return NF_DROP;
+    }
     udp = udp_hdr(skb);
-    
+    if (!udp) {
+        printk(KERN_INFO "kdai: UDP header is NULL -> DROPPING\n");
+        printk(KERN_INFO "kdai: DROPPING\n\n");
+        return NF_DROP;
+    }
+
+    printk(KERN_INFO "kdai: UDP Source Port: %u\n", ntohs(udp->source));
+    printk(KERN_INFO "kdai: UDP Destination Port: %u\n", ntohs(udp->dest));
+
     if (udp->source == htons(DHCP_SERVER_PORT) || udp->source == htons(DHCP_CLIENT_PORT)) {
         printk(KERN_INFO "\nkdai: !! Hooked DHCP PACKET !!");
         payload = (struct dhcp*) ((unsigned char *)udp + sizeof(struct udphdr));
@@ -300,6 +369,13 @@ static unsigned int ip_hook(void* priv, struct sk_buff* skb, const struct nf_hoo
             
             switch (dhcp_packet_type) {
                 case DHCP_ACK:{
+                    u16 vlan_id = 0;
+                    if (skb_vlan_tag_present(skb)) {
+                        vlan_id = skb_vlan_tag_get_id(skb);
+                        printk(KERN_INFO "kdai: VLAN ID for DHCPACK was: %d\n", vlan_id);
+                    } else {
+                        printk(KERN_INFO "kdai: DHCPACK had NO VLAN, defaulting VLAN ID to 0\n");
+                    }
                     for (opt = payload->bp_options; *opt != DHCP_OPTION_END; opt += opt[1] + 2) {
                         if (*opt == DHCP_OPTION_LEASE_TIME) {
                             memcpy(&lease_time, &opt[2], 4);
@@ -312,7 +388,7 @@ static unsigned int ip_hook(void* priv, struct sk_buff* skb, const struct nf_hoo
                     #else
                         getnstimeofday(&ts);
                     #endif
-                    entry = find_dhcp_snooping_entry(payload->yiaddr);
+                    entry = find_dhcp_snooping_entry(payload->yiaddr, vlan_id);
                     if (entry) {
                         memcpy(entry->mac, payload->chaddr, ETH_ALEN);
                         entry->lease_time = ntohl(lease_time);
@@ -320,32 +396,54 @@ static unsigned int ip_hook(void* priv, struct sk_buff* skb, const struct nf_hoo
                         printk(KERN_INFO "kdai: Updated DHCP snooping entry - IP: %pI4, MAC: %pM, Lease Time: %d seconds, Expiry: %d\n",
                             &payload->yiaddr, payload->chaddr, ntohl(lease_time), entry->expires);
                     } else {
-                        insert_dhcp_snooping_entry(
-                            payload->chaddr, payload->yiaddr, ntohl(lease_time), ts.tv_sec + ntohl(lease_time));
-                            printk(KERN_INFO "kdai: Added new DHCP snooping entry - IP: %pI4, MAC: %pM, Lease Time: %d seconds, Expiry: %lld\n",
-                                &payload->yiaddr, payload->chaddr, ntohl(lease_time), ts.tv_sec + ntohl(lease_time));
+                        insert_dhcp_snooping_entry(payload->chaddr, payload->yiaddr, ntohl(lease_time), ts.tv_sec + ntohl(lease_time), vlan_id);
+                            //printk(KERN_INFO "kdai: Added new DHCP snooping entry - IP: %pI4, MAC: %pM, Lease Time: %d seconds, Expiry: %lld\n",
+                            //    &payload->yiaddr, payload->chaddr, ntohl(lease_time), ts.tv_sec + ntohl(lease_time));
+                            printk(KERN_INFO "kdai: Added new DHCP snooping entry - IP: %pI4, MAC: %pM, Lease Time: %d seconds\n",
+                                &payload->yiaddr, payload->chaddr, ntohl(lease_time));
                     }
                     break;
                 }
                 
                 case DHCP_NAK:{
+                    u16 vlan_id = 0;
+                    if (skb_vlan_tag_present(skb)) {
+                        vlan_id = skb_vlan_tag_get_id(skb);
+                        printk(KERN_INFO "kdai: VLAN ID for DHCPACK was: %d\n", vlan_id);
+                    } else {
+                        printk(KERN_INFO "kdai: DHCPACK had NO VLAN, defaulting VLAN ID to 0\n");
+                    }
                     printk(KERN_INFO "kdai: DHCPNAK of %pI4\n", &payload->yiaddr);
-                    entry = find_dhcp_snooping_entry(payload->yiaddr);
+                    entry = find_dhcp_snooping_entry(payload->yiaddr, vlan_id);
                     if (entry) {
-                        delete_dhcp_snooping_entry(entry->ip);
+                        delete_dhcp_snooping_entry(entry->ip, vlan_id);
                     }
                     break;
                 }
 
                 case DHCP_RELEASE:{
+                    u16 vlan_id = 0;
+                    if (skb_vlan_tag_present(skb)) {
+                        vlan_id = skb_vlan_tag_get_id(skb);
+                        printk(KERN_INFO "kdai: VLAN ID for DHCPACK was: %d\n", vlan_id);
+                    } else {
+                        printk(KERN_INFO "kdai: DHCPACK had NO VLAN, defaulting VLAN ID to 0\n");
+                    }
                     printk(KERN_INFO "kdai: DHCPRELEASE of %pI4\n", &payload->ciaddr);
-                    delete_dhcp_snooping_entry(payload->ciaddr);
+                    delete_dhcp_snooping_entry(payload->ciaddr, vlan_id);
                     break;
                 }
 
                 case DHCP_DECLINE:{
+                    u16 vlan_id = 0;
+                    if (skb_vlan_tag_present(skb)) {
+                        vlan_id = skb_vlan_tag_get_id(skb);
+                        printk(KERN_INFO "kdai: VLAN ID for DHCPACK was: %d\n", vlan_id);
+                    } else {
+                        printk(KERN_INFO "kdai: DHCPACK had NO VLAN, defaulting VLAN ID to 0\n");
+                    }
                     printk(KERN_INFO "kdai: DHCPDECLINE of %pI4\n", &payload->ciaddr);
-                    delete_dhcp_snooping_entry(payload->ciaddr);
+                    delete_dhcp_snooping_entry(payload->ciaddr, vlan_id);
                     break;
                 }
             default:
@@ -353,26 +451,39 @@ static unsigned int ip_hook(void* priv, struct sk_buff* skb, const struct nf_hoo
                 break;
             }
       
-        } else status = NF_DROP;
+        } else {
+            printk(KERN_INFO "DHCP packet was not valid\n");
+            printk(KERN_INFO "kdai: DROPPING\n\n");
+            return NF_DROP;
+        }
+    } else {
+        printk(KERN_INFO "(udp->source == htons(DHCP_SERVER_PORT) || udp->source == htons(DHCP_CLIENT_PORT) ) == false -> ACCEPTING\n");
+        printk(KERN_INFO "ACCEPTING\n\n");
+        return NF_ACCEPT;
     }
-   
-    return status;
+    
+    printk(KERN_INFO "ACCEPTING\n\n");
+    return NF_ACCEPT;
+    
 }
 
 
-static int __init kdai_init(void) {
+static int __init kdai_init(void) {   
+    init_vlan_hash_table();
+
+    //Configurations 
+    globally_enabled_DAI = false;
+    static_ACL_Enabled = false;
+    //Enable DAI on all untagged packets
+    add_vlan_to_inspect(0); 
+
+
+    //insert_trusted_interface("enp0s4", 0);
+    //insert_trusted_interface("enp0s6", 0);
     
-    //populate_trusted_interface_list();
-    //insert_trusted_interface("enp0s4");
-    //insert_trusted_interface("ma1");
+    add_vlan_to_inspect(10);
     print_trusted_interface_list();
-    /*
-    if(find_trusted_interface("enp0s4")) {
-        printk(KERN_INFO "Found enp0s4 in the list");
-    } else {
-        printk(KERN_INFO "Did not find enp0s4 in the list");
-    }
-    */
+    print_all_vlans_in_hash();
    
      /*Initialize Generic Hook for rate limiting all Bridged Traffic*/
      brho = (struct nf_hook_ops *) kcalloc(1, sizeof(struct nf_hook_ops), GFP_KERNEL);

--- a/rate_limit.c
+++ b/rate_limit.c
@@ -9,22 +9,23 @@ DEFINE_SPINLOCK(rate_lock);
 /**
  * get_rate_limit_entry - Search for a rate limit entry by interface name.
  * @iface_name: The name of the interface to look up.
+ * @vlan_id: The vlan_id to match for Dynamic Arp Inspeciton.
  *
  * This function looks through the rate_limit_list for an entry matching the given
  * interface name. It uses a spinlock to ensure safe access in concurrent contexts.
  *
  * Return: Pointer to the matching rate_limit_entry if found, otherwise NULL.
  */
-static struct rate_limit_entry* get_rate_limit_entry(const char *iface_name) {
+static struct rate_limit_entry* get_rate_limit_entry(const char *iface_name, u16 vlan_id) {
     struct rate_limit_entry *entry;
     unsigned long flags;
 
     //Acquire the spin lock to safely traverse the lsit
     spin_lock_irqsave(&rate_lock, flags);
 
-    //Iterate through the list to find a matching interface name
+    //Iterate through the list to find a matching interface name and vlan id
     list_for_each_entry(entry, &rate_limit_list, list) {
-        if(strncmp(entry->iface_name, iface_name, IFNAMSIZ) == 0){
+        if(strncmp(entry->iface_name, iface_name, IFNAMSIZ) == 0 && entry->vlan_id == vlan_id){
             spin_unlock_irqrestore(&rate_lock, flags);
             return entry;
         }
@@ -37,6 +38,7 @@ static struct rate_limit_entry* get_rate_limit_entry(const char *iface_name) {
 /**
  * create_rate_limit_entry - Create and insert a new rate limit entry.
  * @iface_name: The name of the interface to add.
+ * @vlan_id: The vlan_id to match for Dynamic Arp Inspeciton.
  *
  * This function allocates and initializes a new rate limit entry for a network
  * interface if one does not already exist. It adds the new entry to the
@@ -44,12 +46,12 @@ static struct rate_limit_entry* get_rate_limit_entry(const char *iface_name) {
  *
  * Return: Pointer to the new entry on success, or NULL if it already exists or allocation fails.
  */
-static struct rate_limit_entry* create_rate_limit_entry(const char *iface_name) {
+static struct rate_limit_entry* create_rate_limit_entry(const char *iface_name, u16 vlan_id) {
     struct rate_limit_entry *entry;
     unsigned long flags;
 
     //If the entry already exists return null
-    entry = get_rate_limit_entry(iface_name);
+    entry = get_rate_limit_entry(iface_name, vlan_id);
     if(entry != NULL){
         return NULL;
     }
@@ -64,7 +66,8 @@ static struct rate_limit_entry* create_rate_limit_entry(const char *iface_name) 
     //Populate the new entry
     strscpy(entry->iface_name, iface_name, IFNAMSIZ);
     entry->packet_count = 0;
-    entry->last_packet_time = 0;
+    entry->last_packet_time = jiffies;
+    entry->vlan_id = vlan_id;
 
     //Add the new entry to our list
     spin_lock_irqsave(&rate_lock, flags);
@@ -89,19 +92,17 @@ static struct rate_limit_entry* create_rate_limit_entry(const char *iface_name) 
  * Return: true if the rate limit has been exceeded and the packet should be dropped, 
  *         false if the packet can be processed.
  */
-bool rate_limit_reached(struct sk_buff* skb){
-    struct net_device *dev = skb->dev;
+bool rate_limit_reached(const char *interface_name, u16 vlan_id){
     struct rate_limit_entry *entry;
     unsigned long current_time = jiffies;
-
     // Get or create a rate limit entry for the interface
-    printk(KERN_INFO "kdai: Getting the current rate limit entry for %s\n", dev->name);
-    entry = get_rate_limit_entry(dev->name);
+    printk(KERN_INFO "kdai: Getting the current rate limit entry for %s\n", interface_name);
+    entry = get_rate_limit_entry(interface_name, vlan_id);
     //If we did not already have an entry
     if (entry == NULL) {
         //Attempt to create an entry
         printk(KERN_INFO "kdai: No rate limit entry existed creating one...\n");
-        entry = create_rate_limit_entry(dev->name);
+        entry = create_rate_limit_entry(interface_name, vlan_id);
         //If we could not create an entry
         if (entry == NULL) {
             //Drop packets by default
@@ -117,7 +118,7 @@ bool rate_limit_reached(struct sk_buff* skb){
     //( the earliest valid timestamp when a new packet can be processes is entry->last_packet_time + msecs_to_jiffies(RATE_LIMIT_WINDOW) )
     if (time_after(current_time, entry->last_packet_time + msecs_to_jiffies(RATE_LIMIT_WINDOW))) {
         // Reset the packet_count and last_packet_received time
-        printk(KERN_INFO "kdai: Time window has elapsed, reset the packet count for %s\n", dev->name);
+        printk(KERN_INFO "kdai: Time window has elapsed, reset the packet count for %s\n", interface_name);
         entry->packet_count = 0; 
         entry->last_packet_time = current_time;
     }

--- a/rate_limit.h
+++ b/rate_limit.h
@@ -1,13 +1,13 @@
 #include "common.h"
 
 struct rate_limit_entry {
-    char iface_name[IFNAMSIZ];  // Store the interface name
-    unsigned int packet_count;  // Count of packets received
-    unsigned long last_packet_time;  // Time of the last packet received
-    struct list_head list;
-
+    char iface_name[IFNAMSIZ];          // Store the interface name
+    unsigned int packet_count;          // Count of packets received
+    unsigned long last_packet_time;     // Time of the last packet received
+    u16 vlan_id;
+    struct list_head list;              
 };
 
 // Function declarations
-bool rate_limit_reached(struct  sk_buff* skb);
+bool rate_limit_reached(const char *interface_name, u16 vlan_id);
 void clean_rate_limit_table(void);

--- a/trustedInterfaces.c
+++ b/trustedInterfaces.c
@@ -15,13 +15,14 @@ void populate_trusted_interface_list(void) {
     struct net_device *dev;
     // Iterate over all network interfaces
     for_each_netdev(&init_net, dev) {
-        insert_trusted_interface(dev->name);
+        insert_trusted_interface(dev->name, 0);
     }
 }
 
 /**
  * insert_trusted_interface - Insert a new interface into the trusted list.
  * @device_name: The name of the trusted interface to insert
+ * @vlan_id: The vlan associated for DAI
  * 
  * This fucntion inserts the name of a network interface into teh trusted interface list. 
  * It first checks if the interface already exists in the list using find_trusted_interface. 
@@ -33,12 +34,12 @@ void populate_trusted_interface_list(void) {
  * Return: This fucntion returns 1 if the interface name was added, 0 if it already exists,
  * and -1 if mmory allocaiton failed
  */
-int insert_trusted_interface(const char *device_name) {
+int insert_trusted_interface(const char *device_name, u16 vlan_id) {
 
     struct interface_entry *new_entry;
 
     //If we found that device already return
-    if(find_trusted_interface(device_name)){
+    if(find_trusted_interface(device_name, vlan_id)){
         return 0;
     }
 
@@ -52,6 +53,7 @@ int insert_trusted_interface(const char *device_name) {
     // Copy the device name safely
     strncpy(new_entry->name, device_name, IFNAMSIZ - 1);
     new_entry->name[IFNAMSIZ - 1] = '\0'; // Ensure null termination
+    new_entry->vlan_id = vlan_id;
 
     // Initialize the list field of the new entry
     INIT_LIST_HEAD(&new_entry->list);
@@ -68,6 +70,7 @@ int insert_trusted_interface(const char *device_name) {
 /**
  * find_trusted_interface - Find an interface in the trusted list.
  * @interface_name: The name of the interaface to find
+ * @vlan_id: The vlan associated for DAI
  * 
  * This function searches the trusted interface list for an entry that matches the given interface name.
  * If a matching entry is found, the function returns the name of th einterface. If no match is found the
@@ -75,12 +78,12 @@ int insert_trusted_interface(const char *device_name) {
  * 
  * Return: The name of the trusted interface if found, or NULL if not found.
  */
-const char* find_trusted_interface(const char *interface_name) {
+const char* find_trusted_interface(const char *interface_name, u16 vlan_id) {
     struct interface_entry *entry;
 
     // Loop through the list to find a matching interface name
     list_for_each_entry(entry, &trusted_interface_list, list) {
-        if (strncmp(entry->name, interface_name, IFNAMSIZ) == 0) {
+        if (strncmp(entry->name, interface_name, IFNAMSIZ) == 0 && entry->vlan_id == vlan_id) {
             return entry->name; // Interface found, return interface
         }
     }
@@ -99,18 +102,23 @@ const char* find_trusted_interface(const char *interface_name) {
 void print_trusted_interface_list(void) {
     struct interface_entry *entry;
 
-    printk(KERN_INFO "kdai: List of trusted network interfaces:\n");
+    printk(KERN_INFO "kdai: ---- List of trusted network interfaces ---\n");
 
     //If the list is empty notify the user
     if(trusted_list_size == 0) {
-        printk(KERN_INFO "!!(The list is currently empty) All interfaces are assumed Untrusted!!\n");
+        printk(KERN_INFO "kdai: The list is currently empty!\n");
+        printk(KERN_INFO "kdai: All interfaces are assumed Untrusted.\n");
+        printk(KERN_INFO "kdai: ---- End of Trusted Network Interfaces List ---\n\n");
         return;
     }
 
     //Iterate and print each entry
     list_for_each_entry(entry, &trusted_interface_list, list) {
-        printk(KERN_INFO " - %s\n", entry->name);
+        printk(KERN_INFO " - Interface:\t%s \t\t VLAN:%u\n", entry->name, entry->vlan_id);
     }
+    
+    printk(KERN_INFO "kdai: ---- End of Trusted Network Interfaces List ---\n\n");
+
 }
 
 /**

--- a/trustedInterfaces.h
+++ b/trustedInterfaces.h
@@ -5,15 +5,16 @@ struct interface_entry {
     char name[IFNAMSIZ];    // Store trusted interface name
                             // IFNAMSIZ is a constant in the linux kernel
                             // that defines the maximum length of a network interface
+    u16 vlan_id;            //The vlan associated with DAI
     struct list_head list;  // Point to the next item in the linked list 
 };
 
 // Function declarations
 void populate_trusted_interface_list(void);
 
-int insert_trusted_interface(const char *device_name);
+int insert_trusted_interface(const char *device_name, u16 vlan_id);
 
-const char* find_trusted_interface(const char *interface_name);
+const char* find_trusted_interface(const char *interface_name, u16 vlan_id);
 
 void print_trusted_interface_list(void);
 

--- a/vlan.c
+++ b/vlan.c
@@ -1,0 +1,74 @@
+#include "vlan.h"
+#include <linux/kernel.h>
+#include <linux/hash.h>
+#include <linux/slab.h>
+
+#define VLAN_HASH_BITS 8
+#define VLAN_HASH_SIZE (1 << VLAN_HASH_BITS)
+
+static struct hlist_head vlan_hash_table[VLAN_HASH_SIZE];
+
+// Hash function
+static inline unsigned int vlan_hash(u16 vlan_id) {
+    return hash_32(vlan_id, VLAN_HASH_BITS);
+}
+
+void init_vlan_hash_table(void) {
+    int i;
+    for (i = 0; i < VLAN_HASH_SIZE; i++) {
+        INIT_HLIST_HEAD(&vlan_hash_table[i]);  // Initialize each hash table bucket
+    }
+}
+
+// Add VLAN to be inspected
+void add_vlan_to_inspect(u16 vlan_id) {
+    unsigned int hash = vlan_hash(vlan_id);
+    struct vlan_hash_entry *entry = kmalloc(sizeof(struct vlan_hash_entry), GFP_KERNEL);
+    if (!entry)
+        return;
+
+    entry->vlan_id = vlan_id;
+    hlist_add_head(&entry->node, &vlan_hash_table[hash]);
+}
+
+// Check if VLAN should be inspected
+bool vlan_should_be_inspected(u16 vlan_id) {
+    unsigned int hash = vlan_hash(vlan_id);
+    struct vlan_hash_entry *entry;
+
+    hlist_for_each_entry(entry, &vlan_hash_table[hash], node) {
+        if (entry->vlan_id == vlan_id)
+            return true;
+    }
+    return false;
+}
+
+// To remove a VLAN
+void remove_vlan_from_inspect(u16 vlan_id) {
+    unsigned int hash = vlan_hash(vlan_id);
+    struct vlan_hash_entry *entry;
+
+    hlist_for_each_entry(entry, &vlan_hash_table[hash], node) {
+        if (entry->vlan_id == vlan_id) {
+            hlist_del(&entry->node);
+            kfree(entry);
+            return;
+        }
+    }
+}
+
+// Print all VLANs currently in the hash table
+void print_all_vlans_in_hash(void) {
+    int i;
+    struct vlan_hash_entry *entry;
+
+    printk(KERN_INFO "kdai: ---- VLANs in Hash Table ----\n");
+
+    for (i = 0; i < VLAN_HASH_SIZE; i++) {
+        hlist_for_each_entry(entry, &vlan_hash_table[i], node) {
+            printk(KERN_INFO "kdai: VLAN ID: %u \t(Hash Index: %d)\n", entry->vlan_id, i);
+        }
+    }
+
+    printk(KERN_INFO "kdai: ---- End of VLAN List ----\n\n");
+}

--- a/vlan.h
+++ b/vlan.h
@@ -1,0 +1,16 @@
+#include "common.h"
+
+struct vlan_hash_entry {
+    u16 vlan_id;
+    struct hlist_node node;
+};
+
+void add_vlan_to_inspect(u16 vlan_id);
+
+bool vlan_should_be_inspected(u16 vlan_id);
+
+void remove_vlan_from_inspect(u16 vlan_id);
+
+void print_all_vlans_in_hash(void);
+
+void init_vlan_hash_table(void);


### PR DESCRIPTION
This PR introduces support for Dynamic ARP Inspection (DAI) on a per-VLAN basis, with the option to enable global inspection mode. This ensures DAI decisions are scoped to specific VLAN contexts unless explicitly overridden to be for all incoming packets.

Features & Changes

- Packets are only inspected if their VLAN ID is in the configured list (vlan_should_be_inspected). This list can be controlled by administrators
- DHCP snooping entries now include VLAN ID and are matched against both IP and VLAN.
- Trusted interfaces are also now tracked per VLAN (find_trusted_interface now takes VLAN ID).
- Rate limiting is scoped per-interface and now per-VLAN as well
- Global Inspection Mode (globally_enabled_DAI)

When enabled, all ARP packets are inspected regardless of VLAN tagging or VLAN existence. Packets are assigned a default vlan_id = 0, and all DAI logic is executed using this ID.
- VLAN_ID 0 is automatically inserted into the hashing table for inspection
