### PR TITLE
Add Test Cases adjusted for DAI per VLAN

### DIFF
--- a/.github/workflows/dai-testing.yml
+++ b/.github/workflows/dai-testing.yml
@@ -48,3 +48,8 @@ jobs:
       - name: Run Test_Malformed_ARP_Request
         working-directory: ./tests
         run: ./Test_Malformed_ARP_Request.sh
+
+      # Run Test_Static_Entry_In_The_ARP_Table
+      - name: Run Test_Static_Entry_In_The_ARP_Table
+        working-directory: ./tests
+        run: ./Test_Static_Entry_In_The_ARP_Table.sh

--- a/.github/workflows/dai-testing.yml
+++ b/.github/workflows/dai-testing.yml
@@ -53,3 +53,8 @@ jobs:
       - name: Run Test_Static_Entry_In_The_ARP_Table
         working-directory: ./tests
         run: ./Test_Static_Entry_In_The_ARP_Table.sh
+
+      # Run Test_Rate_Limiting
+      - name: Run Test_Rate_Limiting
+        working-directory: ./tests
+        run: ./Test_Rate_Limiting.sh

--- a/.github/workflows/dai-testing.yml
+++ b/.github/workflows/dai-testing.yml
@@ -43,3 +43,8 @@ jobs:
       - name: Run Test_ARP_Poisoning
         working-directory: ./tests
         run: ./Test_ARP_Poisoning.sh
+
+      # Run Test_Malformed_ARP_Request
+      - name: Run Test_Malformed_ARP_Request
+        working-directory: ./tests
+        run: ./Test_Malformed_ARP_Request.sh

--- a/.github/workflows/dai-testing.yml
+++ b/.github/workflows/dai-testing.yml
@@ -38,3 +38,8 @@ jobs:
       - name: Run Test_Communication_from_Acknowledged_Sources
         working-directory: ./tests
         run: ./Test_Communication_from_Acknowledged_Sources.sh
+
+      # Run Test_ARP_Poisoning
+      - name: Run Test_ARP_Poisoning
+        working-directory: ./tests
+        run: ./Test_ARP_Poisoning.sh

--- a/.github/workflows/dai-testing.yml
+++ b/.github/workflows/dai-testing.yml
@@ -33,3 +33,8 @@ jobs:
       - name: Run Test_Communication_from_Unacknowledged_Sources
         working-directory: ./tests
         run: ./Test_Communication_from_Unacknowledged_Sources.sh
+
+      # Run Test_Communication_from_Acknowledged_Sources
+      - name: Run Test_Communication_from_Acknowledged_Sources
+        working-directory: ./tests
+        run: ./Test_Communication_from_Acknowledged_Sources.sh

--- a/.github/workflows/dai-testing.yml
+++ b/.github/workflows/dai-testing.yml
@@ -28,3 +28,8 @@ jobs:
       - name: Run Test_Insert_Kernel_Module
         working-directory: ./tests
         run: ./Test_Insert_Kernel_Module.sh
+
+      # Run Test_Communication_from_Unacknowledged_Sources
+      - name: Run Test_Communication_from_Unacknowledged_Sources
+        working-directory: ./tests
+        run: ./Test_Communication_from_Unacknowledged_Sources.sh


### PR DESCRIPTION
The following test cases were added to the GitHub workflow to ensure future additions do not break existing features. Previous tests assuming global behavior were invalid and replaced with VLAN-scoped test cases. DAI now correctly only inspects ARP packets for VLANs explicitly configured and matches DHCP/ARP/trust on a per-VLAN basis. This matches how DAI operates in real switching hardware.
