### PR TITLE
Refactor Rate Limiting Test Cases for Packet Drop Validation

### DIFF
--- a/.github/workflows/dai-testing.yml
+++ b/.github/workflows/dai-testing.yml
@@ -54,7 +54,12 @@ jobs:
         working-directory: ./tests
         run: ./Test_Static_Entry_In_The_ARP_Table.sh
 
-      # Run Test_Rate_Limiting
-      - name: Run Test_Rate_Limiting
+      # Run Test_Above_Rate_Limit
+      - name: Run Test_Above_Rate_Limit
         working-directory: ./tests
-        run: ./Test_Rate_Limiting.sh
+        run: ./Test_Above_Rate_Limit.sh
+      
+      # Run Test_Below_Rate_Limit
+      - name: Run Test_Below_Rate_Limit
+        working-directory: ./tests
+        run: ./Test_Below_Rate_Limit.sh

--- a/main.c
+++ b/main.c
@@ -478,10 +478,11 @@ static int __init kdai_init(void) {
     add_vlan_to_inspect(0); 
 
 
+    //Additional Configuraitons
     //insert_trusted_interface("enp0s4", 0);
     //insert_trusted_interface("enp0s6", 0);
-    
     add_vlan_to_inspect(10);
+
     print_trusted_interface_list();
     print_all_vlans_in_hash();
    

--- a/tests/Test_ARP_Poisoning.sh
+++ b/tests/Test_ARP_Poisoning.sh
@@ -122,7 +122,7 @@ echo
 make -C .. install
 
 echo
-echo "=== Testing DAI Accepts Packets From DHCP Acknowledged Sources ==="
+echo "=== Testing DAI Drops Spoofed Packets ==="
 echo
 #Update the DHCP table with 192.168.1.1 and 192.168.1.2
 sudo ip netns exec ns1 python3 ./helperPythonFilesForCustomPackets/DHCP_without_VLAN.py

--- a/tests/Test_Above_Rate_Limit.sh
+++ b/tests/Test_Above_Rate_Limit.sh
@@ -122,7 +122,7 @@ echo
 make -C .. install
 
 echo
-echo "=== Testing DAI Accepts Packets From DHCP Acknowledged Sources ==="
+echo "=== Testing DAI Drops Packets When Rate Limit is Reached ==="
 echo
 #Send arp packets above the rate limit
 sudo ip netns exec ns1 python3 ./helperPythonFilesForCustomPackets/send_ARP_Packets_Above_Limit.py

--- a/tests/Test_Above_Rate_Limit.sh
+++ b/tests/Test_Above_Rate_Limit.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Test_DAI_Allows_Communication_from_DHCP_Acknowledged_Sources.sh
+# Test_Above_Rate_Limit.sh
 # This script checks if the kernel module drops packets after the defualt 15 packets per second rate limit was exceeded
 
 set -euo pipefail  #treat unset vars as errors

--- a/tests/Test_Below_Rate_Limit.sh
+++ b/tests/Test_Below_Rate_Limit.sh
@@ -1,0 +1,148 @@
+#!/bin/bash
+
+# Test_Below_Rate_Limit.sh
+# This script checks if the kernel module does NOT drop packets below the defualt 15 packets per second rate limit
+
+set -euo pipefail  #treat unset vars as errors
+
+# Track current command for debugging
+last_command=""
+current_command=""
+trap 'last_command=$current_command; current_command=$BASH_COMMAND' DEBUG
+
+# Log which command caused exit
+trap 'echo ""; echo "TEST FAILED - Script exited during: \"$last_command\"" >&2' ERR
+
+# Define the cleanup function
+cleanup() {
+    echo
+    echo "=== Cleaning Up ==="
+    echo
+    make -C .. remove || true
+
+    sudo ip netns exec ns1 ip link set lo down || true
+    sudo ip netns exec ns2 ip link set lo down || true
+    sudo ip netns exec ns1 ip link set veth0 down || true
+    sudo ip netns exec ns2 ip link set veth3 down || true
+    sudo ip link set veth1 down || true
+    sudo ip link set veth2 down || true
+    sudo ip link set br1 down || true
+
+    sudo ip netns delete ns1 || true
+    sudo ip netns delete ns2 || true
+    sudo ip link delete br1 || true
+    echo
+    echo "=== Clean-up Complete ==="
+}
+
+# Always run cleanup on exit (normal or error)
+trap cleanup EXIT
+sudo dmesg -C
+sudo dmesg -n 3
+cleanup
+
+echo
+echo "=== Updating Package list ==="
+echo
+sudo apt-get update
+
+echo
+echo "=== Installing build tools ==="
+echo
+sudo apt-get install -y build-essential
+
+echo
+echo "=== Installing Networking tools ==="
+echo
+sudo sudo apt install -y bridge-utils && sudo apt install -y iproute2
+
+echo
+echo "=== Installing Python Dependencies ==="
+echo
+sudo apt-get update
+sudo apt-get install -y python3-pip
+sudo pip3 install scapy
+sudo apt-get install -y dsniff 
+
+echo
+echo "=== Create Bridges, Virtual Interfaces, and Namespaces ==="
+echo
+sudo ip link add name br1 type bridge
+sudo ip link add veth0 type veth peer name veth1
+sudo ifconfig veth0 hw ether e2:c8:14:a6:4f:ed
+sudo ip link add veth2 type veth peer name veth3
+sudo ifconfig veth3 hw ether  3a:18:70:ca:91:b2
+sudo ip netns add ns1
+sudo ip netns add ns2
+
+echo
+echo "=== Assigning Interfaces to Namespaces ==="
+echo
+sudo ip link set veth0 netns ns1
+sudo ip link set veth3 netns ns2
+
+echo
+echo "=== Attaching Interfaces to Bridge ==="
+echo
+sudo ip link set veth1 master br1
+sudo ip link set veth2 master br1
+
+echo
+echo "=== Setting Up Namespace Test Enviornment ==="
+echo
+sudo ip netns exec ns1 ip addr add 192.168.1.1/24 dev veth0
+sudo ip netns exec ns2 ip addr add 192.168.1.2/24 dev veth3
+
+echo
+echo "=== Bringing Up Interfaces ==="
+echo
+sudo ip link set br1 up
+sudo ip link set veth1 up
+sudo ip link set veth2 up
+sudo ip netns exec ns1 ip link set veth0 up
+sudo ip netns exec ns2 ip link set veth3 up
+sudo ip netns exec ns1 ip link set lo up
+sudo ip netns exec ns2 ip link set lo up
+
+echo
+echo "=== Ensure Working Test Environment ==="
+echo
+sudo ip netns exec ns1 python3 ./helperPythonFilesForCustomPackets/ARP_Request_And_Response_Without_VLAN_ID.py
+sudo dmesg -C
+
+echo
+echo "=== Running make to build the module ==="
+echo
+make -C ..
+
+echo
+echo "=== Running make install to insert the module ==="
+
+echo
+make -C .. install
+
+echo
+echo "=== Testing DAI Accepts Packets From DHCP Acknowledged Sources ==="
+echo
+
+#Send arp packets above the rate limit
+sudo ip netns exec ns1 python3 ./helperPythonFilesForCustomPackets/send_ARP_Packets_Below_Limit.py
+sudo dmesg | grep "DROPPING"
+if ! dmesg | grep -q "Packet hit the rate limit."; then
+    # Pattern not found
+    echo "Packet hit the rate limit.' was NOT found"
+    
+    echo
+    echo "Test Passed!"     
+    echo
+    
+    sudo dmesg -n 7
+    exit 
+else
+    # Pattern was found
+    echo "Failed: 'Packet hit the rate limit.' WAS found"
+
+    sudo dmesg -n 7
+    exit 
+fi
+

--- a/tests/Test_Below_Rate_Limit.sh
+++ b/tests/Test_Below_Rate_Limit.sh
@@ -122,7 +122,7 @@ echo
 make -C .. install
 
 echo
-echo "=== Testing DAI Accepts Packets From DHCP Acknowledged Sources ==="
+echo "=== Testing DAI Accepts Packets when Rate Limit is Not Yet Reached ==="
 echo
 
 #Send arp packets above the rate limit

--- a/tests/Test_Communication_from_Unacknowledged_Sources.sh
+++ b/tests/Test_Communication_from_Unacknowledged_Sources.sh
@@ -121,7 +121,7 @@ echo
 make -C .. install
 
 echo
-echo "=== Testing DAI Filtering From Unvalidated Sources ==="
+echo "=== Testing DAI Filtering From Unacknowledged Sources ==="
 echo
 #Send arp request without first being added to the DHCP or Static ARP table
 sudo ip netns exec ns1 python3 ./helperPythonFilesForCustomPackets/ARP_Request_And_Response_With_VLAN_ID.py

--- a/tests/helperPythonFilesForCustomPackets/send_ARP_Packets_Below_Limit.py
+++ b/tests/helperPythonFilesForCustomPackets/send_ARP_Packets_Below_Limit.py
@@ -7,5 +7,5 @@ packet = Ether(dst="0c:83:01:80:00:03", src="0c:38:66:2f:00:02") / \
 
 # Send at a rate of 5 packets per second
 for i in range(100):
-        sendp(packet, iface = "enp0s5", verbose=0)
+        sendp(packet, iface = "veth0", verbose=0)
         time.sleep(0.2) #0.2s = 5 per second

--- a/tests/helperPythonFilesForCustomPackets/send_ARP_Packets_Below_Limit_original.py
+++ b/tests/helperPythonFilesForCustomPackets/send_ARP_Packets_Below_Limit_original.py
@@ -1,9 +1,11 @@
 from scapy.all import ARP, Ether, sendp
+import time
 
 packet = Ether(dst="0c:83:01:80:00:03", src="0c:38:66:2f:00:02") / \
          ARP(op=2, psrc="192.168.122.48", hwsrc="0c:38:66:2f:00:02",
                     pdst="192.168.122.110", hwdst="0c:83:01:80:00:03")
 
-# Send 200 packets as fast as possible
+# Send at a rate of 5 packets per second
 for i in range(100):
         sendp(packet, iface = "enp0s5", verbose=0)
+        time.sleep(0.2) #0.2s = 5 per second


### PR DESCRIPTION
This pull request separates the rate limiting test cases into two distinct tests. The first test verifies that packets are dropped when the rate limit is exceeded, ensuring that our rate limiting mechanism functions correctly under overload conditions. The second test checks that packets are not dropped when the rate limit is not exceeded, confirming that normal traffic is handled appropriately.