### PR TITLE
Add Support for Passing Kernel Parameters at Module Load Time

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+    "files.associations": {
+        "trustedinterfaces.h": "c"
+    }
+}

--- a/Makefile
+++ b/Makefile
@@ -7,14 +7,27 @@ obj-m := ${MODULE}.o
 ${MODULE}-objs := main.o dhcp.o trustedInterfaces.o rate_limit.o vlan.o
 
 all:
+	@echo "Building the module..."
 	make -C ${KDIR} M=${PWD} modules
+	@echo "Cleaning up temporary files..."
 	rm -r -f *.mod.c .*.cmd *.symvers *.o
 install:
+	@echo "Installing the module..."
 	sudo cp kdai.ko ${MDIR}/.
 	sudo depmod
 	sudo modprobe kdai
+	@echo "Module installed successfully."
+load_with_params:
+	@echo "Installing the module for loading with parameters..."
+	sudo cp kdai.ko ${MDIR}/.
+	sudo depmod
+	@echo "Module is Ready to Load."
+	@echo "Use 'sudo modprobe kdai [globally_enabled_DAI=<0|1> static_ACL_Enabled=<0|1>]' to load the module."
 remove:
+	@echo "Removing the module..."
 	sudo modprobe -r kdai
 	sudo rm ${MDIR}/kdai.ko
+	@echo "Module removed successfully."
 clean:
+	@echo "Cleaning up build artifacts..."
 	make -C  ${KDIR} M=${PWD} clean

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ load_with_params:
 	sudo cp kdai.ko ${MDIR}/.
 	sudo depmod
 	@echo "Module is Ready to Load."
-	@echo "Use 'sudo modprobe kdai [globally_enabled_DAI=<0|1> static_ACL_Enabled=<0|1>]' to load the module."
+	@echo "Use 'sudo modprobe kdai [globally_enabled_DAI=<0|1> static_ACL_Enabled=<0|1>...]' to load the module."
 remove:
 	@echo "Removing the module..."
 	sudo modprobe -r kdai

--- a/dhcp.c
+++ b/dhcp.c
@@ -73,7 +73,8 @@ void clean_dhcp_snooping_table(void) {
     spin_unlock_irqrestore(&slock, flags);
 }
 
-
+//Continuously check the list of DHCP snooping entries and remove any entries that ave expired based on their
+//expiration time
 int dhcp_thread_handler(void *arg) {
     struct list_head* curr, *next;
     struct dhcp_snooping_entry* entry;

--- a/main.c
+++ b/main.c
@@ -222,6 +222,10 @@ static bool is_trusted(const char *interface_name, u16 vlan_id) {
 
 static unsigned int bridge_hook(void* priv, struct sk_buff* skb, const struct nf_hook_state* state) {
 
+    struct net_device *dev;
+    struct ethhdr * eth;
+    u16 vlan_id;
+
     if (unlikely(!skb)) {
         // Drop if skb is NULL
         printk(KERN_INFO "kdai: SKB was null");
@@ -229,11 +233,8 @@ static unsigned int bridge_hook(void* priv, struct sk_buff* skb, const struct nf
         return NF_DROP;  
     }
 
-    struct net_device *dev;
-    struct ethhdr * eth;
     dev = skb->dev;
     eth = eth_hdr(skb);
-    u16 vlan_id;
 
     //Used only for debugging purpouses
     if(strcmp(dev->name,"enp0s7")==0 || strcmp(dev->name,"ma1")==0 ){
@@ -337,6 +338,8 @@ static unsigned int ip_hook(void* priv, struct sk_buff* skb, const struct nf_hoo
         struct timespec ts;
     #endif
     struct dhcp_snooping_entry* entry;
+    __be16 encapsulated_proto;
+
     if (unlikely(!skb)) {
         printk(KERN_INFO "kdai: Skb was null\n");
         printk(KERN_INFO "kdai: DROPPING\n\n");
@@ -352,7 +355,7 @@ static unsigned int ip_hook(void* priv, struct sk_buff* skb, const struct nf_hoo
         skb_set_transport_header(skb, skb_network_offset(skb) + ip_hdr(skb)->ihl * 4);
     }
 
-    __be16 encapsulated_proto = vlan_get_protocol(skb);
+    encapsulated_proto = vlan_get_protocol(skb);
     if (encapsulated_proto != htons(ETH_P_IP)) {
         printk(KERN_INFO "kdai: Not an IPv4 packet, skipping -> ACCEPTING\n");
         printk(KERN_INFO "kdai: ACCEPTING\n\n");

--- a/main.c
+++ b/main.c
@@ -489,19 +489,13 @@ static unsigned int ip_hook(void* priv, struct sk_buff* skb, const struct nf_hoo
 
 static int __init kdai_init(void) {   
 
-    printk(KERN_INFO "kdai: Module loaded with parameters:\n");
-    printk(KERN_INFO "kdai: globally_enabled_DAI=%d, static_ACL_Enabled=%d\n\n", 
-        globally_enabled_DAI, static_ACL_Enabled);
-    
-    
     init_vlan_hash_table();
     parse_vlans(vlans_to_inspect);
     parse_interfaces_and_vlan(trusted_interfaces);
 
-    //Enable DAI on all untagged packets
-    add_vlan_to_inspect(0); 
-    add_vlan_to_inspect(10);
-
+    printk(KERN_INFO "kdai: Module loaded with parameters:\n");
+    printk(KERN_INFO "kdai: globally_enabled_DAI=%d, static_ACL_Enabled=%d\n\n", 
+        globally_enabled_DAI, static_ACL_Enabled);
     print_trusted_interface_list();
     print_all_vlans_in_hash();
    

--- a/main.c
+++ b/main.c
@@ -18,6 +18,11 @@ bool static_ACL_Enabled = false; //Default is false
 module_param(static_ACL_Enabled, bool, 0644);
 MODULE_PARM_DESC(static_ACL_Enabled, "Enable or disable DAI Inspection using static ACLs ONLY. Static Entries for packets not found in the ARP table will be dropped.");
 
+char * vlans_to_inspect = NULL; //Default is None
+module_param(vlans_to_inspect, charp, 0644);
+MODULE_PARM_DESC(vlans_to_inspect, "Comma-separated list of VLANs DAI should inspect");
+
+
 MODULE_LICENSE("GPL");
 MODULE_AUTHOR("M. Sami GURPINAR <sami.gurpinar@gmail.com>. Edited by Korel Ucpinar <korelucpinar@gmail.com>");
 MODULE_DESCRIPTION("kdai(Kernel Dynamic ARP Inspection) is a linux kernel module to defend against arp spoofing");
@@ -480,14 +485,13 @@ static int __init kdai_init(void) {
     printk(KERN_INFO "kdai: Module loaded with parameters:\n");
     printk(KERN_INFO "kdai: globally_enabled_DAI=%d, static_ACL_Enabled=%d\n\n", 
         globally_enabled_DAI, static_ACL_Enabled);
+    
+    
     init_vlan_hash_table();
+    parse_vlans(vlans_to_inspect);
 
-    //Configurations 
-    //globally_enabled_DAI = false;
-    //static_ACL_Enabled = false;
     //Enable DAI on all untagged packets
     add_vlan_to_inspect(0); 
-
 
     //Additional Configuraitons
     //insert_trusted_interface("enp0s4", 0);

--- a/main.c
+++ b/main.c
@@ -22,6 +22,10 @@ char * vlans_to_inspect = NULL; //Default is None
 module_param(vlans_to_inspect, charp, 0644);
 MODULE_PARM_DESC(vlans_to_inspect, "Comma-separated list of VLANs DAI should inspect");
 
+char * trusted_interfaces = NULL; //Default is None
+module_param(trusted_interfaces, charp, 0644);
+MODULE_PARM_DESC(trusted_interfaces, "Comma-separated list of Interfaces:VLAN_ID that are considered to be trusted");
+
 
 MODULE_LICENSE("GPL");
 MODULE_AUTHOR("M. Sami GURPINAR <sami.gurpinar@gmail.com>. Edited by Korel Ucpinar <korelucpinar@gmail.com>");
@@ -489,6 +493,7 @@ static int __init kdai_init(void) {
     
     init_vlan_hash_table();
     parse_vlans(vlans_to_inspect);
+    parse_interfaces_and_vlan(trusted_interfaces);
 
     //Enable DAI on all untagged packets
     add_vlan_to_inspect(0); 

--- a/main.c
+++ b/main.c
@@ -500,10 +500,6 @@ static int __init kdai_init(void) {
 
     //Enable DAI on all untagged packets
     add_vlan_to_inspect(0); 
-
-    //Additional Configuraitons
-    //insert_trusted_interface("enp0s4", 0);
-    //insert_trusted_interface("enp0s6", 0);
     add_vlan_to_inspect(10);
 
     print_trusted_interface_list();

--- a/tests/Test_ARP_Poisoning.sh
+++ b/tests/Test_ARP_Poisoning.sh
@@ -116,10 +116,11 @@ echo
 make -C ..
 
 echo
-echo "=== Running make install to insert the module ==="
+echo "=== Running make load_with_params to insert the module ==="
 
 echo
-make -C .. install
+make -C .. load_with_params
+sudo modprobe kdai vlans_to_inspect="0,10"
 
 echo
 echo "=== Testing DAI Drops Spoofed Packets ==="

--- a/tests/Test_Above_Rate_Limit.sh
+++ b/tests/Test_Above_Rate_Limit.sh
@@ -116,10 +116,11 @@ echo
 make -C ..
 
 echo
-echo "=== Running make install to insert the module ==="
+echo "=== Running make load_with_params to insert the module ==="
 
 echo
-make -C .. install
+make -C .. load_with_params
+sudo modprobe kdai vlans_to_inspect="0,10"
 
 echo
 echo "=== Testing DAI Drops Packets When Rate Limit is Reached ==="

--- a/tests/Test_Below_Rate_Limit.sh
+++ b/tests/Test_Below_Rate_Limit.sh
@@ -127,7 +127,6 @@ echo
 
 #Send arp packets above the rate limit
 sudo ip netns exec ns1 python3 ./helperPythonFilesForCustomPackets/send_ARP_Packets_Below_Limit.py
-sudo dmesg | grep "DROPPING"
 if ! dmesg | grep -q "Packet hit the rate limit."; then
     # Pattern not found
     echo "Packet hit the rate limit.' was NOT found"

--- a/tests/Test_Below_Rate_Limit.sh
+++ b/tests/Test_Below_Rate_Limit.sh
@@ -116,10 +116,11 @@ echo
 make -C ..
 
 echo
-echo "=== Running make install to insert the module ==="
+echo "=== Running make load_with_params to insert the module ==="
 
 echo
-make -C .. install
+make -C .. load_with_params
+sudo modprobe kdai vlans_to_inspect="0,10"
 
 echo
 echo "=== Testing DAI Accepts Packets when Rate Limit is Not Yet Reached ==="

--- a/tests/Test_Communication_from_Acknowledged_Sources.sh
+++ b/tests/Test_Communication_from_Acknowledged_Sources.sh
@@ -116,9 +116,10 @@ echo
 make -C ..
 
 echo
-echo "=== Running make install to insert the module ==="
+echo "=== Running make load_with_params to insert the module ==="
 echo
-make -C .. install
+make -C .. load_with_params
+sudo modprobe kdai vlans_to_inspect="0,10"
 
 echo
 echo "=== Testing DAI Accepts Packets From DHCP Acknowledged Sources ==="

--- a/tests/Test_Communication_from_Unacknowledged_Sources.sh
+++ b/tests/Test_Communication_from_Unacknowledged_Sources.sh
@@ -116,9 +116,10 @@ echo
 make -C ..
 
 echo
-echo "=== Running make install to insert the module ==="
+echo "=== Running make load_with_params to insert the module ==="
 echo
-make -C .. install
+make -C .. load_with_params
+sudo modprobe kdai vlans_to_inspect="0,10"
 
 echo
 echo "=== Testing DAI Filtering From Unacknowledged Sources ==="

--- a/tests/Test_Malformed_ARP_Request.sh
+++ b/tests/Test_Malformed_ARP_Request.sh
@@ -116,10 +116,10 @@ echo
 make -C ..
 
 echo
-echo "=== Running make install to insert the module ==="
+echo "=== Running make load_with_params to insert the module ==="
 echo
-make -C .. install
-
+make -C .. load_with_params
+sudo modprobe kdai vlans_to_inspect="0,10"
 echo
 echo "=== Testing DAI Malformed ARP Request ==="
 echo

--- a/tests/Test_Static_Entry_In_The_ARP_Table.sh
+++ b/tests/Test_Static_Entry_In_The_ARP_Table.sh
@@ -116,9 +116,10 @@ echo
 make -C ..
 
 echo
-echo "=== Running make install to insert the module ==="
+echo "=== Running make load_with_params to insert the module ==="
 echo
-make -C .. install
+make -C .. load_with_params
+sudo modprobe kdai vlans_to_inspect="0,10"
 
 echo
 echo "=== Testing Static Arp Entry In ARP Table ==="

--- a/trustedInterfaces.c
+++ b/trustedInterfaces.c
@@ -62,7 +62,7 @@ int insert_trusted_interface(const char *device_name, u16 vlan_id) {
     list_add_tail(&new_entry->list, &trusted_interface_list);
     trusted_list_size++;
 
-    printk(KERN_INFO "Added interface: %s\n", new_entry->name);
+    //printk(KERN_INFO "Added interface: %s\n", new_entry->name);
 
     return 1;
 }
@@ -107,14 +107,14 @@ void print_trusted_interface_list(void) {
     //If the list is empty notify the user
     if(trusted_list_size == 0) {
         printk(KERN_INFO "kdai: The list is currently empty!\n");
-        printk(KERN_INFO "kdai: All interfaces are assumed Untrusted.\n");
+        printk(KERN_INFO "kdai: All interfaces are Untrusted.\n");
         printk(KERN_INFO "kdai: ---- End of Trusted Network Interfaces List ---\n\n");
         return;
     }
 
     //Iterate and print each entry
     list_for_each_entry(entry, &trusted_interface_list, list) {
-        printk(KERN_INFO " - Interface:\t%s \t\t VLAN:%u\n", entry->name, entry->vlan_id);
+        printk(KERN_INFO " - VLAN ID:\t%u \t\t Interface:\t%s\n",  entry->vlan_id, entry->name);
     }
     
     printk(KERN_INFO "kdai: ---- End of Trusted Network Interfaces List ---\n\n");
@@ -149,6 +149,7 @@ void parse_interfaces_and_vlan(char * interfaces_and_vlan) {
     char * vlan_id_str;
     char * str;
     char *to_free;
+    u16 vlan_id;
 
     if(interfaces_and_vlan==NULL){
         return;
@@ -174,7 +175,6 @@ void parse_interfaces_and_vlan(char * interfaces_and_vlan) {
         //Move to the start of the vlan_id
         vlan_id_str++;
 
-        u16 vlan_id;
         //Convert the token into an unsigned 16 bit integer
         if(kstrtou16(vlan_id_str, 10, &vlan_id) == 0){
             //After converting add the interface and vlan to the trusted list

--- a/trustedInterfaces.h
+++ b/trustedInterfaces.h
@@ -19,3 +19,5 @@ const char* find_trusted_interface(const char *interface_name, u16 vlan_id);
 void print_trusted_interface_list(void);
 
 void free_trusted_interface_list(void);
+
+void parse_interfaces_and_vlan(char * interfaces_and_vlan);

--- a/vlan.c
+++ b/vlan.c
@@ -2,11 +2,13 @@
 #include <linux/kernel.h>
 #include <linux/hash.h>
 #include <linux/slab.h>
+#include<linux/sort.h>
 
 #define VLAN_HASH_BITS 8
 #define VLAN_HASH_SIZE (1 << VLAN_HASH_BITS)
 
 static struct hlist_head vlan_hash_table[VLAN_HASH_SIZE];
+int currentNumberOfVLANs;
 
 // Hash function
 static inline unsigned int vlan_hash(u16 vlan_id) {
@@ -22,11 +24,18 @@ void init_vlan_hash_table(void) {
 
 // Add VLAN to be inspected
 void add_vlan_to_inspect(u16 vlan_id) {
+
+    if(vlan_should_be_inspected(vlan_id)){
+        //We already have this vlan
+        return;
+    }
+
     unsigned int hash = vlan_hash(vlan_id);
     struct vlan_hash_entry *entry = kmalloc(sizeof(struct vlan_hash_entry), GFP_KERNEL);
     if (!entry)
         return;
 
+    currentNumberOfVLANs++;
     entry->vlan_id = vlan_id;
     hlist_add_head(&entry->node, &vlan_hash_table[hash]);
 }
@@ -57,18 +66,62 @@ void remove_vlan_from_inspect(u16 vlan_id) {
     }
 }
 
+int compare_u16(const void * a, const void * b){
+    return *(u16 *)a - *(u16 *)b;
+}
 // Print all VLANs currently in the hash table
 void print_all_vlans_in_hash(void) {
     int i;
+    int count = 0;
     struct vlan_hash_entry *entry;
+    u16 vlan_ids [currentNumberOfVLANs];
+
 
     printk(KERN_INFO "kdai: ---- VLANs in Hash Table ----\n");
 
     for (i = 0; i < VLAN_HASH_SIZE; i++) {
         hlist_for_each_entry(entry, &vlan_hash_table[i], node) {
-            printk(KERN_INFO "kdai: VLAN ID: %u \t(Hash Index: %d)\n", entry->vlan_id, i);
+            //intk(KERN_INFO "kdai: VLAN ID: %u \t(Hash Index: %d)\n", entry->vlan_id, i);
+            vlan_ids[count++] = entry->vlan_id;
         }
     }
 
+    sort(vlan_ids, count, sizeof(u16), compare_u16, NULL);
+    for(i=0; i < count; i++) {
+        printk(KERN_INFO "kdai: VLAN ID:  %u\n", vlan_ids[i]);
+    }
     printk(KERN_INFO "kdai: ---- End of VLAN List ----\n\n");
+}
+
+//Taken a string of comma seperated vlans and add those vlans to the inspection list
+void parse_vlans(char * vlans) {
+    char * token;
+    char * str;
+    char *to_free;
+
+    if(vlans==NULL){
+        return;
+    }
+
+    //Duplicate the string to safely modify it
+    to_free = kstrdup(vlans,GFP_KERNEL);
+    str = to_free;
+
+    //Split the vlan string into parts 
+    //Ex. 100,200,300 -> 100'\0'200'\0'300'\0'
+    while( (token = strsep(&str, ",")) != NULL) {
+        //Token will return the start of the string
+        u16 vlan_id;
+
+        //Conver the token into an unsigned 16 bit integer
+        if(kstrtou16(token, 10, &vlan_id) == 0){
+            //After converting add the vlan to the inpsection list
+            add_vlan_to_inspect(vlan_id); 
+        } else {
+            printk(KERN_INFO "Invalid VLAN_ID: %s\n", token);
+        }
+    }
+    //Free the allocated memory
+    kfree(to_free);
+
 }

--- a/vlan.h
+++ b/vlan.h
@@ -14,3 +14,5 @@ void remove_vlan_from_inspect(u16 vlan_id);
 void print_all_vlans_in_hash(void);
 
 void init_vlan_hash_table(void);
+
+void parse_vlans(char * vlans);


### PR DESCRIPTION
This PR adds support for configurable kernel parameters when loading the module via `modprobe`. It allows dynamic specification of values such as`globally_enabled_DAI`, `static_ACL_Enabled`,  `trusted_interfaces`, and `vlans_to_inspect`, removing the need for hardcoded configuration in the source code.

- Introduced `module_param` declarations for relevant parameters
- Updated parsing logic to handle input passed via modprobe
- Refactored `main.c` to avoid static defaults for interface and VLAN configuration

Example Usage

```bash
sudo modprobe kdai trusted_interfaces="enp0s1:100,enp0s2:200" vlans_to_inspect="10,20,30"
