### PR TITLE
Add Support for Passing Kernel Parameters at Module Load Time

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,14 +7,33 @@ obj-m := ${MODULE}.o
 ${MODULE}-objs := main.o dhcp.o trustedInterfaces.o rate_limit.o vlan.o
 
 all:
+	@echo "Building the module..."
+	@echo "Building the module..."
 	make -C ${KDIR} M=${PWD} modules
+	@echo "Cleaning up temporary files..."
+	@echo "Cleaning up temporary files..."
 	rm -r -f *.mod.c .*.cmd *.symvers *.o
 install:
+	@echo "Installing the module..."
+	@echo "Installing the module..."
 	sudo cp kdai.ko ${MDIR}/.
 	sudo depmod
 	sudo modprobe kdai
+	@echo "Module installed successfully."
+load_with_params:
+	@echo "Installing the module for loading with parameters..."
+	sudo cp kdai.ko ${MDIR}/.
+	sudo depmod
+	@echo "Module is Ready to Load."
+	@echo "Use 'sudo modprobe kdai [globally_enabled_DAI=<0|1> static_ACL_Enabled=<0|1>...]' to load the module."
 remove:
+	@echo "Removing the module..."
+	@echo "Removing the module..."
 	sudo modprobe -r kdai
 	sudo rm ${MDIR}/kdai.ko
+	@echo "Module removed successfully."
+	@echo "Module removed successfully."
 clean:
+	@echo "Cleaning up build artifacts..."
+	@echo "Cleaning up build artifacts..."
 	make -C  ${KDIR} M=${PWD} clean

--- a/dhcp.c
+++ b/dhcp.c
@@ -73,7 +73,8 @@ void clean_dhcp_snooping_table(void) {
     spin_unlock_irqrestore(&slock, flags);
 }
 
-
+//Continuously check the list of DHCP snooping entries and remove any entries that ave expired based on their
+//expiration time
 int dhcp_thread_handler(void *arg) {
     struct list_head* curr, *next;
     struct dhcp_snooping_entry* entry;

--- a/tests/Test_ARP_Poisoning.sh
+++ b/tests/Test_ARP_Poisoning.sh
@@ -116,10 +116,11 @@ echo
 make -C ..
 
 echo
-echo "=== Running make install to insert the module ==="
+echo "=== Running make load_with_params to insert the module ==="
 
 echo
-make -C .. install
+make -C .. load_with_params
+sudo modprobe kdai vlans_to_inspect="0,10"
 
 echo
 echo "=== Testing DAI Drops Spoofed Packets ==="

--- a/tests/Test_Above_Rate_Limit.sh
+++ b/tests/Test_Above_Rate_Limit.sh
@@ -116,10 +116,11 @@ echo
 make -C ..
 
 echo
-echo "=== Running make install to insert the module ==="
+echo "=== Running make load_with_params to insert the module ==="
 
 echo
-make -C .. install
+make -C .. load_with_params
+sudo modprobe kdai vlans_to_inspect="0,10"
 
 echo
 echo "=== Testing DAI Drops Packets When Rate Limit is Reached ==="

--- a/tests/Test_Below_Rate_Limit.sh
+++ b/tests/Test_Below_Rate_Limit.sh
@@ -116,10 +116,11 @@ echo
 make -C ..
 
 echo
-echo "=== Running make install to insert the module ==="
+echo "=== Running make load_with_params to insert the module ==="
 
 echo
-make -C .. install
+make -C .. load_with_params
+sudo modprobe kdai vlans_to_inspect="0,10"
 
 echo
 echo "=== Testing DAI Accepts Packets when Rate Limit is Not Yet Reached ==="
@@ -127,7 +128,6 @@ echo
 
 #Send arp packets above the rate limit
 sudo ip netns exec ns1 python3 ./helperPythonFilesForCustomPackets/send_ARP_Packets_Below_Limit.py
-sudo dmesg | grep "DROPPING"
 if ! dmesg | grep -q "Packet hit the rate limit."; then
     # Pattern not found
     echo "Packet hit the rate limit.' was NOT found"

--- a/tests/Test_Communication_from_Acknowledged_Sources.sh
+++ b/tests/Test_Communication_from_Acknowledged_Sources.sh
@@ -116,9 +116,10 @@ echo
 make -C ..
 
 echo
-echo "=== Running make install to insert the module ==="
+echo "=== Running make load_with_params to insert the module ==="
 echo
-make -C .. install
+make -C .. load_with_params
+sudo modprobe kdai vlans_to_inspect="0,10"
 
 echo
 echo "=== Testing DAI Accepts Packets From DHCP Acknowledged Sources ==="

--- a/tests/Test_Communication_from_Unacknowledged_Sources.sh
+++ b/tests/Test_Communication_from_Unacknowledged_Sources.sh
@@ -116,9 +116,10 @@ echo
 make -C ..
 
 echo
-echo "=== Running make install to insert the module ==="
+echo "=== Running make load_with_params to insert the module ==="
 echo
-make -C .. install
+make -C .. load_with_params
+sudo modprobe kdai vlans_to_inspect="0,10"
 
 echo
 echo "=== Testing DAI Filtering From Unacknowledged Sources ==="

--- a/tests/Test_Malformed_ARP_Request.sh
+++ b/tests/Test_Malformed_ARP_Request.sh
@@ -116,10 +116,10 @@ echo
 make -C ..
 
 echo
-echo "=== Running make install to insert the module ==="
+echo "=== Running make load_with_params to insert the module ==="
 echo
-make -C .. install
-
+make -C .. load_with_params
+sudo modprobe kdai vlans_to_inspect="0,10"
 echo
 echo "=== Testing DAI Malformed ARP Request ==="
 echo

--- a/tests/Test_Static_Entry_In_The_ARP_Table.sh
+++ b/tests/Test_Static_Entry_In_The_ARP_Table.sh
@@ -116,9 +116,10 @@ echo
 make -C ..
 
 echo
-echo "=== Running make install to insert the module ==="
+echo "=== Running make load_with_params to insert the module ==="
 echo
-make -C .. install
+make -C .. load_with_params
+sudo modprobe kdai vlans_to_inspect="0,10"
 
 echo
 echo "=== Testing Static Arp Entry In ARP Table ==="

--- a/trustedInterfaces.c
+++ b/trustedInterfaces.c
@@ -62,7 +62,7 @@ int insert_trusted_interface(const char *device_name, u16 vlan_id) {
     list_add_tail(&new_entry->list, &trusted_interface_list);
     trusted_list_size++;
 
-    printk(KERN_INFO "Added interface: %s\n", new_entry->name);
+    //printk(KERN_INFO "Added interface: %s\n", new_entry->name);
 
     return 1;
 }
@@ -107,14 +107,14 @@ void print_trusted_interface_list(void) {
     //If the list is empty notify the user
     if(trusted_list_size == 0) {
         printk(KERN_INFO "kdai: The list is currently empty!\n");
-        printk(KERN_INFO "kdai: All interfaces are assumed Untrusted.\n");
+        printk(KERN_INFO "kdai: All interfaces are Untrusted.\n");
         printk(KERN_INFO "kdai: ---- End of Trusted Network Interfaces List ---\n\n");
         return;
     }
 
     //Iterate and print each entry
     list_for_each_entry(entry, &trusted_interface_list, list) {
-        printk(KERN_INFO " - Interface:\t%s \t\t VLAN:%u\n", entry->name, entry->vlan_id);
+        printk(KERN_INFO " - VLAN ID:\t%u \t\t Interface:\t%s\n",  entry->vlan_id, entry->name);
     }
     
     printk(KERN_INFO "kdai: ---- End of Trusted Network Interfaces List ---\n\n");
@@ -142,3 +142,48 @@ void free_trusted_interface_list(void) {
     }
 }
 
+
+//Taken a string of comma seperated vlans and add those vlans to the inspection list
+void parse_interfaces_and_vlan(char * interfaces_and_vlan) {
+    char * token;
+    char * vlan_id_str;
+    char * str;
+    char *to_free;
+    u16 vlan_id;
+
+    if(interfaces_and_vlan==NULL){
+        return;
+    }
+
+    //Duplicate the string to safely modify it
+    to_free = kstrdup(interfaces_and_vlan,GFP_KERNEL);
+    str = to_free;
+
+    //Split the interfaces_and_vlan string into parts 
+    //Ex. enp0s1:100,enp0s2:200,enp0s3:300 -> enp0s1:100'\0'enp0s2:200'\0'enp0s3:300'\0'
+    while( (token = strsep(&str, ",")) != NULL) {
+        //Token will return the start of the string
+        //Ex. enp0s1:100
+
+        //Find the deliminator and null terminate the interface from the vlan;
+        vlan_id_str = strstr(token, ":");
+        if (!vlan_id_str) {
+            printk(KERN_INFO "Invalid format (missing colon): %s\n", token);
+            continue;
+        }
+        *vlan_id_str='\0';
+        //Move to the start of the vlan_id
+        vlan_id_str++;
+
+        //Convert the token into an unsigned 16 bit integer
+        if(kstrtou16(vlan_id_str, 10, &vlan_id) == 0){
+            //After converting add the interface and vlan to the trusted list
+            insert_trusted_interface(token, vlan_id);
+        } else {
+            printk(KERN_INFO "Invalid VLAN_ID: %s\n", token);
+        }
+    }
+    //Free the allocated memory
+    kfree(to_free);
+
+}

--- a/trustedInterfaces.h
+++ b/trustedInterfaces.h
@@ -19,3 +19,5 @@ const char* find_trusted_interface(const char *interface_name, u16 vlan_id);
 void print_trusted_interface_list(void);
 
 void free_trusted_interface_list(void);
+
+void parse_interfaces_and_vlan(char * interfaces_and_vlan);

--- a/vlan.h
+++ b/vlan.h
@@ -14,3 +14,5 @@ void remove_vlan_from_inspect(u16 vlan_id);
 void print_all_vlans_in_hash(void);
 
 void init_vlan_hash_table(void);
+
+void parse_vlans(char * vlans);


### PR DESCRIPTION
This PR adds support for configurable kernel parameters when loading the module via `modprobe`. It allows dynamic specification of values such as`globally_enabled_DAI`, `static_ACL_Enabled`,  `trusted_interfaces`, and `vlans_to_inspect`, removing the need for hardcoded configuration in the source code.

- Introduced `module_param` declarations for relevant parameters
- Updated parsing logic to handle input passed via modprobe
- Refactored `main.c` to avoid static defaults for interface and VLAN configuration

Example Usage

```bash
sudo modprobe kdai trusted_interfaces="enp0s1:100,enp0s2:200" vlans_to_inspect="10,20,30"
