### PR TITLE
Update VLAN Test Case

### DIFF
--- a/main.c
+++ b/main.c
@@ -281,7 +281,7 @@ static unsigned int bridge_hook(void* priv, struct sk_buff* skb, const struct nf
         if(vlan_should_be_inspected(vlan_id) || globally_enabled_DAI) {
             //YES
             //Print Logs
-            if(vlan_should_be_inspected(vlan_id)) printk(KERN_INFO "kdai: vlan_id WAS FOUND in the hash table. INSPECTING\n");
+            if(vlan_should_be_inspected(vlan_id)) printk(KERN_INFO "kdai: vlan_id %u WAS FOUND in the hash table. INSPECTING\n", vlan_id);
             if(globally_enabled_DAI) printk(KERN_INFO "kdai: INSPECTING ALL\n");
 
             //4th Is the interface not trusted?
@@ -313,7 +313,7 @@ static unsigned int bridge_hook(void* priv, struct sk_buff* skb, const struct nf
         } else {
             //NO
             //No need to Inspect packet it was not in our list of VLANS to Inspect
-            printk(KERN_INFO "kdai: vlan_id was NOT in the HASH TABLE -> ACCEPTING\n");
+            printk(KERN_INFO "kdai: vlan_id %u was NOT in the HASH TABLE\n", vlan_id);
             printk(KERN_INFO "kdai: ACCEPTING\n\n");
             return NF_ACCEPT;
         }

--- a/tests/Test_add_VLAN_to_Inspect.sh
+++ b/tests/Test_add_VLAN_to_Inspect.sh
@@ -59,16 +59,18 @@ echo
 echo "=== Running make load_with_params to insert the module ==="
 echo
 make -C .. load_with_params
-sudo modprobe kdai vlans_to_inspect="0,10"
+sudo modprobe kdai vlans_to_inspect="10"
 
 echo
 echo "=== Testing DAI compares VLAN_IDs to added entries ==="
 echo
-#Send and ARP Request and wait for a Response
-#Requests will default to VLAN 0, and will match with veth0 and veth3
+#Send ARP Request with a VLAN that is configured for inspection
+sudo ip netns exec ns1 python3 ./helperPythonFilesForCustomPackets/ARP_Request_And_Response_With_VLAN_ID.py
+#Send ARP Request with a VLAN that is NOT configured for inspection (Default VLAN_ID)
 sudo ip netns exec ns1 python3 ./helperPythonFilesForCustomPackets/ARP_Request_And_Response_Without_VLAN_ID.py
 
-ARP_EXIT_STATUS=$(sudo dmesg | tail -n 100 | grep "vlan_id WAS FOUND in the hash table.")
+ARP_EXIT_STATUS=$(sudo dmesg | tail -n 100 | grep "vlan_id 10 WAS FOUND in the hash table. INSPECTING")
+ARP_EXIT_STATUS=$(sudo dmesg | tail -n 100 | grep "vlan_id 0 was NOT in the HASH TABLE")
 
 echo
 echo "Test Passed!"          


### PR DESCRIPTION
Update the VLAN Test case to test Dynamic ARP inspection is performed on incoming packets for VLANs that were added. DAI is not performed for VLANs that were not added