### PR TITLE
Add function to free all VLAN entries from hash table

### DIFF
--- a/main.c
+++ b/main.c
@@ -563,6 +563,7 @@ static void __exit kdai_exit(void) {
     clean_dhcp_snooping_table();
     kthread_stop(dhcp_thread);
     free_trusted_interface_list();
+    free_all_vlan_entries();
     clean_rate_limit_table();
 
 }

--- a/vlan.c
+++ b/vlan.c
@@ -143,3 +143,27 @@ void parse_vlans(char * vlans) {
     kfree(to_free);
 
 }
+
+void free_all_vlan_entries(void) {
+    //loop counter for hashtable buckets
+    int i;
+    //Pointer to VLAN hash entry for traversal
+    struct vlan_hash_entry *entry;
+    //Temporary pointer used for safe iteraiton
+    struct hlist_node *tmp;
+
+    //Loop through each bucked in the VLAN hash table
+    for(i = 0; i < VLAN_HASH_SIZE; i++) {
+        //Get the pointer to the current hash bucket
+        struct hlist_head * head = &vlan_hash_table[i];
+        //Safely iterate through each entry in the current hash bucket
+        hlist_for_each_entry_safe(entry, tmp, head, node) {
+            //Unlink the entry form the haslist
+            hlist_del(&entry->node);
+            //ree the memory allocated for this entry
+            kfree(entry);
+        }
+    }
+    // Reset the global counter tracking number of VLANs
+    currentNumberOfVLANs = 0;  
+}

--- a/vlan.h
+++ b/vlan.h
@@ -16,3 +16,5 @@ void print_all_vlans_in_hash(void);
 void init_vlan_hash_table(void);
 
 void parse_vlans(char * vlans);
+
+void free_all_vlan_entries(void);


### PR DESCRIPTION
Introduced free_all_vlan_entries() to safely deallocate all dynamically allocated VLAN entries and reset the VLAN tracking state.