### PR TITLE
Implement Dynamic Kernel Module Parameters for DAI Inspection, Static ACLs, VLANs, and Trusted Interfaces

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,12 +17,6 @@ install:
 	sudo depmod
 	sudo modprobe kdai
 	@echo "Module installed successfully."
-load_with_params:
-	@echo "Installing the module for loading with parameters..."
-	sudo cp kdai.ko ${MDIR}/.
-	sudo depmod
-	@echo "Module is Ready to Load."
-	@echo "Use 'sudo modprobe kdai [globally_enabled_DAI=<0|1> static_ACL_Enabled=<0|1>...]' to load the module."
 remove:
 	@echo "Removing the module..."
 	sudo modprobe -r kdai

--- a/dhcp.c
+++ b/dhcp.c
@@ -11,6 +11,12 @@ void insert_dhcp_snooping_entry(u8 *mac, u32 ip, u32 lease_time, u32 expire_time
     struct dhcp_snooping_entry* entry;
     unsigned long flags;
 
+    // Check if VLAN ID is within valid range (1-4094)
+    if (vlan_id < 1 || vlan_id >= 4095) {
+        printk(KERN_INFO "Invalid VLAN ID: %u. Must be between 1 (Default All) and 4094.\n", vlan_id);
+        return;
+    }
+
     entry = kmalloc(sizeof(struct dhcp_snooping_entry), GFP_KERNEL);
     if (!entry) {
         printk(KERN_INFO "kdai: kmalloc failed\n");

--- a/main.c
+++ b/main.c
@@ -11,20 +11,148 @@
 
 
 bool globally_enabled_DAI = false; //Default is false
-module_param(globally_enabled_DAI, bool, 0644);
+//module_param(globally_enabled_DAI, bool, 0644);
 MODULE_PARM_DESC(globally_enabled_DAI, "Enable or disable DAI Inspection for all Packets. All packets will be assumed to be in the same VLAN.");
+static int set_globally_enabled_DAI(const char *val, const struct kernel_param *kp)
+{
+    bool tmp;
+    // Convert the input string (e.g., "1" or "true") to a boolean (0 or 1)
+    int ret = kstrtobool(val, &tmp);
+    if (ret < 0) {
+        printk(KERN_INFO "kdai: globally_enabled_DAI was NOT updated, input was invalid\n\n");
+        return ret;
+    }
+
+    // Log the old value before updating and the new value after
+    printk(KERN_INFO "kdai: globally_enabled_DAI was updated from %d to %d\n\n", globally_enabled_DAI, tmp);
+    
+    globally_enabled_DAI = tmp;
+
+    return 0;
+}
+static const struct kernel_param_ops globally_enabled_DAI_ops = {
+    .set = set_globally_enabled_DAI, //This funciton will be called whenever the static_ACL_Enabled variable is written too
+    .get = param_get_bool, //This function will be called whenever the static_ACL_Enabled variable is read
+};
+module_param_cb(globally_enabled_DAI, &globally_enabled_DAI_ops, &globally_enabled_DAI, 0644);
+
 
 bool static_ACL_Enabled = false; //Default is false
-module_param(static_ACL_Enabled, bool, 0644);
+//module_param(static_ACL_Enabled, bool, 0644);
 MODULE_PARM_DESC(static_ACL_Enabled, "Enable or disable DAI Inspection using static ACLs ONLY. Static Entries for packets not found in the ARP table will be dropped.");
+static int set_static_acl(const char *val, const struct kernel_param *kp)
+{
+    bool tmp;
+    // Convert the input string (e.g., "1" or "true") to a boolean (0 or 1)
+    int ret = kstrtobool(val, &tmp);
+    if (ret < 0) {
+        printk(KERN_INFO "kdai: static_ACL_Enabled was NOT updated, input was invalid\n\n");
+        return ret;
+    }
+
+    // Log a message to the kernel log to confirm the update
+    printk(KERN_INFO "kdai: static_ACL_Enabled updated to: %d to %d\n\n", static_ACL_Enabled, tmp);
+
+    static_ACL_Enabled = tmp;
+    return 0;
+}
+static const struct kernel_param_ops static_acl_ops = {
+    .set = set_static_acl, //This funciton will be called whenever the static_ACL_Enabled variable is written too
+    .get = param_get_bool, //This function will be called whenever the static_ACL_Enabled variable is read
+};
+module_param_cb(static_ACL_Enabled, &static_acl_ops, &static_ACL_Enabled, 0644);
+
 
 char * vlans_to_inspect = NULL; //Default is None
-module_param(vlans_to_inspect, charp, 0644);
+//module_param(vlans_to_inspect, charp, 0644);
 MODULE_PARM_DESC(vlans_to_inspect, "Comma-separated list of VLANs DAI should inspect");
+static int set_vlans_to_inspect(const char *val, const struct kernel_param *kp){
+    char *to_free; // Declare to_free for duplicating the string
+    char *str;
+    
+    // If the input string is empty, just return
+    if (val == NULL) {
+        printk(KERN_INFO "kdai: No VLANs to inspect (empty input).\n\n");
+        return 0;
+    }
+    if (*val == '\0') {
+        printk(KERN_INFO "kdai: Clearing VLANs To Inspect list\n\n");
+        free_all_vlan_entries();
+        print_all_vlans_in_hash();
+        return 0;
+    }
+
+    // Parse the incoming string of VLANs
+    to_free = kstrdup(val, GFP_KERNEL);
+    if (!to_free)
+        return -ENOMEM; // Memory allocation failed
+
+    str = to_free;
+
+    //Remove all VLAN_ID entries from the list
+    free_all_vlan_entries();
+
+     //Add all entries that are specified in new val
+    parse_vlans(to_free);
+
+    //Free allocate dmmemory
+    kfree(to_free);
+
+    printk(KERN_INFO "kdai: VLANs to inspect updated.\n\n");
+    print_all_vlans_in_hash();
+    return 0;
+}
+static const struct kernel_param_ops vlans_to_inspect_ops = {
+    .set = set_vlans_to_inspect, //This funciton will be called whenever the static_ACL_Enabled variable is written too
+    .get = param_get_charp, //This function will be called whenever the static_ACL_Enabled variable is read
+};
+module_param_cb(vlans_to_inspect, &vlans_to_inspect_ops, &vlans_to_inspect, 0644);
+
 
 char * trusted_interfaces = NULL; //Default is None
-module_param(trusted_interfaces, charp, 0644);
+//module_param(trusted_interfaces, charp, 0644);
 MODULE_PARM_DESC(trusted_interfaces, "Comma-separated list of Interfaces:VLAN_ID that are considered to be trusted");
+static int set_trusted_interfaces(const char *val, const struct kernel_param *kp){
+    char *to_free; // Declare to_free for duplicating the string
+    char *str;
+    
+    // If the input string is empty, just return
+    if (val == NULL) {
+        printk(KERN_INFO "kdai: Empty input for Trusted Interfaces.\n\n");
+        return 0;
+    }
+    if(*val == '\0') {
+        printk(KERN_INFO "kdai: Clearing Trusted list\n\n");
+        free_trusted_interface_list();
+        print_trusted_interface_list();
+        return 0;
+    }
+
+    // Parse the incoming string of VLANs
+    to_free = kstrdup(val, GFP_KERNEL);
+    if (!to_free)
+        return -ENOMEM; // Memory allocation failed
+
+    str = to_free;
+
+    //Remove all trusted entries from the list
+    free_trusted_interface_list();
+
+    //Add all entries that are specified in new val
+    parse_interfaces_and_vlan(to_free);
+
+    //Free allocate dmmemory
+    kfree(to_free);
+
+    printk(KERN_INFO "kdai: Trusted Interfaces Updated.\n\n");
+    print_trusted_interface_list();
+    return 0;
+}
+static const struct kernel_param_ops trusted_interfaces_ops = {
+    .set = set_trusted_interfaces, //This funciton will be called whenever the static_ACL_Enabled variable is written too
+    .get = param_get_charp, //This function will be called whenever the static_ACL_Enabled variable is read
+};
+module_param_cb(trusted_interfaces, &trusted_interfaces_ops, &trusted_interfaces, 0644);
 
 
 MODULE_LICENSE("GPL");

--- a/rate_limit.c
+++ b/rate_limit.c
@@ -44,7 +44,7 @@ static struct rate_limit_entry* get_rate_limit_entry(const char *iface_name, u16
  * interface if one does not already exist. It adds the new entry to the
  * global rate_limit_list under a spinlock to ensure thread safety.
  *
- * Return: Pointer to the new entry on success, or NULL if it already exists or allocation fails.
+ * Return: Pointer to the new entry on success, or NULL if it already exists, allocation fails, or VLAN was invalid.
  */
 static struct rate_limit_entry* create_rate_limit_entry(const char *iface_name, u16 vlan_id) {
     struct rate_limit_entry *entry;
@@ -53,6 +53,12 @@ static struct rate_limit_entry* create_rate_limit_entry(const char *iface_name, 
     //If the entry already exists return null
     entry = get_rate_limit_entry(iface_name, vlan_id);
     if(entry != NULL){
+        return NULL;
+    }
+
+    // Check if VLAN ID is within valid range (1-4094)
+    if (vlan_id < 1 || vlan_id >= 4095) {
+        printk(KERN_INFO "Invalid VLAN ID: %u. Must be between 1 (Default All) and 4094.\n", vlan_id);
         return NULL;
     }
 

--- a/tests/Test_ARP_Poisoning.sh
+++ b/tests/Test_ARP_Poisoning.sh
@@ -59,8 +59,8 @@ echo
 echo "=== Running make load_with_params to insert the module ==="
 
 echo
-make -C .. load_with_params
-sudo modprobe kdai vlans_to_inspect="0,10"
+make -C .. install
+echo "1, 10" > /sys/module/kdai/parameters/vlans_to_inspect
 
 echo
 echo "=== Testing DAI Drops Spoofed Packets ==="

--- a/tests/Test_ARP_Poisoning.sh
+++ b/tests/Test_ARP_Poisoning.sh
@@ -60,7 +60,7 @@ echo "=== Running make load_with_params to insert the module ==="
 
 echo
 make -C .. install
-sudo echo "1, 10" > /sys/module/kdai/parameters/vlans_to_inspect
+echo "1,10" | sudo tee /sys/module/kdai/parameters/vlans_to_inspect
 
 echo
 echo "=== Testing DAI Drops Spoofed Packets ==="

--- a/tests/Test_ARP_Poisoning.sh
+++ b/tests/Test_ARP_Poisoning.sh
@@ -60,7 +60,7 @@ echo "=== Running make load_with_params to insert the module ==="
 
 echo
 make -C .. install
-echo "1, 10" > /sys/module/kdai/parameters/vlans_to_inspect
+sudo echo "1, 10" > /sys/module/kdai/parameters/vlans_to_inspect
 
 echo
 echo "=== Testing DAI Drops Spoofed Packets ==="

--- a/tests/Test_Above_Rate_Limit.sh
+++ b/tests/Test_Above_Rate_Limit.sh
@@ -58,8 +58,8 @@ echo
 echo "=== Running make load_with_params to insert the module ==="
 
 echo
-make -C .. load_with_params
-sudo modprobe kdai vlans_to_inspect="0,10"
+make -C .. install
+echo "1,10" > /sys/module/kdai/parameters/vlans_to_inspect
 
 echo
 echo "=== Testing DAI Drops Packets When Rate Limit is Reached ==="

--- a/tests/Test_Above_Rate_Limit.sh
+++ b/tests/Test_Above_Rate_Limit.sh
@@ -59,7 +59,7 @@ echo "=== Running make load_with_params to insert the module ==="
 
 echo
 make -C .. install
-sudo echo "1,10" > /sys/module/kdai/parameters/vlans_to_inspect
+echo "1,10" | sudo tee /sys/module/kdai/parameters/vlans_to_inspect
 
 echo
 echo "=== Testing DAI Drops Packets When Rate Limit is Reached ==="

--- a/tests/Test_Above_Rate_Limit.sh
+++ b/tests/Test_Above_Rate_Limit.sh
@@ -59,7 +59,7 @@ echo "=== Running make load_with_params to insert the module ==="
 
 echo
 make -C .. install
-echo "1,10" > /sys/module/kdai/parameters/vlans_to_inspect
+sudo echo "1,10" > /sys/module/kdai/parameters/vlans_to_inspect
 
 echo
 echo "=== Testing DAI Drops Packets When Rate Limit is Reached ==="

--- a/tests/Test_Below_Rate_Limit.sh
+++ b/tests/Test_Below_Rate_Limit.sh
@@ -59,7 +59,7 @@ echo "=== Running make load_with_params to insert the module ==="
 
 echo
 make -C .. install
-sudo echo "1, 10" > /sys/module/kdai/parameters/vlans_to_inspect
+echo "1,10" | sudo tee /sys/module/kdai/parameters/vlans_to_inspect
 
 echo
 echo "=== Testing DAI Accepts Packets when Rate Limit is Not Yet Reached ==="

--- a/tests/Test_Below_Rate_Limit.sh
+++ b/tests/Test_Below_Rate_Limit.sh
@@ -58,8 +58,8 @@ echo
 echo "=== Running make load_with_params to insert the module ==="
 
 echo
-make -C .. load_with_params
-sudo modprobe kdai vlans_to_inspect="0,10"
+make -C .. install
+echo "1, 10" > /sys/module/kdai/parameters/vlans_to_inspect
 
 echo
 echo "=== Testing DAI Accepts Packets when Rate Limit is Not Yet Reached ==="

--- a/tests/Test_Below_Rate_Limit.sh
+++ b/tests/Test_Below_Rate_Limit.sh
@@ -59,7 +59,7 @@ echo "=== Running make load_with_params to insert the module ==="
 
 echo
 make -C .. install
-echo "1, 10" > /sys/module/kdai/parameters/vlans_to_inspect
+sudo echo "1, 10" > /sys/module/kdai/parameters/vlans_to_inspect
 
 echo
 echo "=== Testing DAI Accepts Packets when Rate Limit is Not Yet Reached ==="

--- a/tests/Test_Communication_from_Acknowledged_Sources.sh
+++ b/tests/Test_Communication_from_Acknowledged_Sources.sh
@@ -59,7 +59,7 @@ echo
 echo "=== Running make load_with_params to insert the module ==="
 echo
 make -C .. install
-sudo echo "1,10" > /sys/module/kdai/parameters/vlans_to_inspect
+echo "1,10" | sudo tee /sys/module/kdai/parameters/vlans_to_inspect
 
 echo
 echo "=== Testing DAI Accepts Packets From DHCP Acknowledged Sources ==="

--- a/tests/Test_Communication_from_Acknowledged_Sources.sh
+++ b/tests/Test_Communication_from_Acknowledged_Sources.sh
@@ -59,7 +59,7 @@ echo
 echo "=== Running make load_with_params to insert the module ==="
 echo
 make -C .. install
-echo "1,10" > /sys/module/kdai/parameters/vlans_to_inspect
+sudo echo "1,10" > /sys/module/kdai/parameters/vlans_to_inspect
 
 echo
 echo "=== Testing DAI Accepts Packets From DHCP Acknowledged Sources ==="

--- a/tests/Test_Communication_from_Acknowledged_Sources.sh
+++ b/tests/Test_Communication_from_Acknowledged_Sources.sh
@@ -58,8 +58,8 @@ make -C ..
 echo
 echo "=== Running make load_with_params to insert the module ==="
 echo
-make -C .. load_with_params
-sudo modprobe kdai vlans_to_inspect="0,10"
+make -C .. install
+echo "1,10" > /sys/module/kdai/parameters/vlans_to_inspect
 
 echo
 echo "=== Testing DAI Accepts Packets From DHCP Acknowledged Sources ==="

--- a/tests/Test_Communication_from_Unacknowledged_Sources.sh
+++ b/tests/Test_Communication_from_Unacknowledged_Sources.sh
@@ -58,7 +58,7 @@ echo
 echo "=== Running make load_with_params to insert the module ==="
 echo
 make -C .. install
-sudo echo "1,10" > /sys/module/kdai/parameters/vlans_to_inspect
+echo "1,10" | sudo tee /sys/module/kdai/parameters/vlans_to_inspect
 
 echo
 echo "=== Testing DAI Filtering From Unacknowledged Sources ==="

--- a/tests/Test_Communication_from_Unacknowledged_Sources.sh
+++ b/tests/Test_Communication_from_Unacknowledged_Sources.sh
@@ -58,7 +58,7 @@ echo
 echo "=== Running make load_with_params to insert the module ==="
 echo
 make -C .. install
-echo "1,10" > /sys/module/kdai/parameters/vlans_to_inspect
+sudo echo "1,10" > /sys/module/kdai/parameters/vlans_to_inspect
 
 echo
 echo "=== Testing DAI Filtering From Unacknowledged Sources ==="

--- a/tests/Test_Communication_from_Unacknowledged_Sources.sh
+++ b/tests/Test_Communication_from_Unacknowledged_Sources.sh
@@ -57,8 +57,8 @@ make -C ..
 echo
 echo "=== Running make load_with_params to insert the module ==="
 echo
-make -C .. load_with_params
-sudo modprobe kdai vlans_to_inspect="0,10"
+make -C .. install
+echo "1,10" > /sys/module/kdai/parameters/vlans_to_inspect
 
 echo
 echo "=== Testing DAI Filtering From Unacknowledged Sources ==="

--- a/tests/Test_Load_With_Params_Kernel_Module.sh
+++ b/tests/Test_Load_With_Params_Kernel_Module.sh
@@ -26,7 +26,7 @@ echo
 make -C .. install
 
 echo "=== Load the kernel module  and Change the parameters==="
-sudo echo "1,10" > /sys/module/kdai/parameters/vlans_to_inspect
+echo "1,10" | sudo tee /sys/module/kdai/parameters/vlans_to_inspect
 
 echo
 echo "Test Passed!"

--- a/tests/Test_Load_With_Params_Kernel_Module.sh
+++ b/tests/Test_Load_With_Params_Kernel_Module.sh
@@ -26,7 +26,7 @@ echo
 make -C .. install
 
 echo "=== Load the kernel module  and Change the parameters==="
-echo "1,10" > /sys/module/kdai/parameters/vlans_to_inspect
+sudo echo "1,10" > /sys/module/kdai/parameters/vlans_to_inspect
 
 echo
 echo "Test Passed!"

--- a/tests/Test_Load_With_Params_Kernel_Module.sh
+++ b/tests/Test_Load_With_Params_Kernel_Module.sh
@@ -23,10 +23,10 @@ make -C ..
 echo
 echo "=== Running make load_with_param to prepare the module ==="
 echo
-make -C .. load_with_params
+make -C .. install
 
-echo "=== Running modprobe to load the module ==="
-sudo modprobe kdai vlans_to_inspect="0,10"
+echo "=== Load the kernel module  and Change the parameters==="
+echo "1,10" > /sys/module/kdai/parameters/vlans_to_inspect
 
 echo
 echo "Test Passed!"

--- a/tests/Test_Malformed_ARP_Request.sh
+++ b/tests/Test_Malformed_ARP_Request.sh
@@ -59,7 +59,7 @@ echo
 echo "=== Running make load_with_params to insert the module ==="
 echo
 make -C .. install
-sudo echo "1,10" > /sys/module/kdai/parameters/vlans_to_inspect
+echo "1,10" | sudo tee /sys/module/kdai/parameters/vlans_to_inspect
 echo
 echo "=== Testing DAI Malformed ARP Request ==="
 echo

--- a/tests/Test_Malformed_ARP_Request.sh
+++ b/tests/Test_Malformed_ARP_Request.sh
@@ -58,8 +58,8 @@ make -C ..
 echo
 echo "=== Running make load_with_params to insert the module ==="
 echo
-make -C .. load_with_params
-sudo modprobe kdai vlans_to_inspect="0,10"
+make -C .. install
+echo "1,10" > /sys/module/kdai/parameters/vlans_to_inspect
 echo
 echo "=== Testing DAI Malformed ARP Request ==="
 echo

--- a/tests/Test_Malformed_ARP_Request.sh
+++ b/tests/Test_Malformed_ARP_Request.sh
@@ -59,7 +59,7 @@ echo
 echo "=== Running make load_with_params to insert the module ==="
 echo
 make -C .. install
-echo "1,10" > /sys/module/kdai/parameters/vlans_to_inspect
+sudo echo "1,10" > /sys/module/kdai/parameters/vlans_to_inspect
 echo
 echo "=== Testing DAI Malformed ARP Request ==="
 echo

--- a/tests/Test_Static_Entry_In_The_ARP_Table.sh
+++ b/tests/Test_Static_Entry_In_The_ARP_Table.sh
@@ -58,7 +58,7 @@ echo
 echo "=== Running make load_with_params to insert the module ==="
 echo
 make -C .. install
-sudo echo "1,10" > /sys/module/kdai/parameters/vlans_to_inspect
+echo "1,10" | sudo tee /sys/module/kdai/parameters/vlans_to_inspect
 
 echo
 echo "=== Testing Static Arp Entry In ARP Table ==="

--- a/tests/Test_Static_Entry_In_The_ARP_Table.sh
+++ b/tests/Test_Static_Entry_In_The_ARP_Table.sh
@@ -57,8 +57,8 @@ make -C ..
 echo
 echo "=== Running make load_with_params to insert the module ==="
 echo
-make -C .. load_with_params
-sudo modprobe kdai vlans_to_inspect="0,10"
+make -C .. install
+echo "1,10" > /sys/module/kdai/parameters/vlans_to_inspect
 
 echo
 echo "=== Testing Static Arp Entry In ARP Table ==="

--- a/tests/Test_Static_Entry_In_The_ARP_Table.sh
+++ b/tests/Test_Static_Entry_In_The_ARP_Table.sh
@@ -58,7 +58,7 @@ echo
 echo "=== Running make load_with_params to insert the module ==="
 echo
 make -C .. install
-echo "1,10" > /sys/module/kdai/parameters/vlans_to_inspect
+sudo echo "1,10" > /sys/module/kdai/parameters/vlans_to_inspect
 
 echo
 echo "=== Testing Static Arp Entry In ARP Table ==="

--- a/tests/Test_Trusted_Interfaces.sh
+++ b/tests/Test_Trusted_Interfaces.sh
@@ -59,7 +59,7 @@ echo
 echo "=== Running make load_with_params to insert the module ==="
 echo
 make -C .. install
-echo "1,10" > /sys/module/kdai/parameters/vlans_to_inspect
+sudo echo "1,10" > /sys/module/kdai/parameters/vlans_to_inspect
 echo "veth1:1,veth2:1" > /sys/module/kdai/parameters/trusted_interfaces
 
 echo

--- a/tests/Test_Trusted_Interfaces.sh
+++ b/tests/Test_Trusted_Interfaces.sh
@@ -59,8 +59,8 @@ echo
 echo "=== Running make load_with_params to insert the module ==="
 echo
 make -C .. install
-sudo echo "1,10" > /sys/module/kdai/parameters/vlans_to_inspect
-echo "veth1:1,veth2:1" > /sys/module/kdai/parameters/trusted_interfaces
+echo "1,10" | sudo tee /sys/module/kdai/parameters/vlans_to_inspect
+echo "veth1:1,veth2:1" | sudo tee /sys/module/kdai/parameters/trusted_interfaces
 
 echo
 echo "=== Testing DAI Accepts Packets From Trusted Interfaces ==="

--- a/tests/Test_Trusted_Interfaces.sh
+++ b/tests/Test_Trusted_Interfaces.sh
@@ -58,14 +58,15 @@ make -C ..
 echo
 echo "=== Running make load_with_params to insert the module ==="
 echo
-make -C .. load_with_params
-sudo modprobe kdai vlans_to_inspect="0,10" trusted_interfaces="veth1:0,veth2:0"
+make -C .. install
+echo "1,10" > /sys/module/kdai/parameters/vlans_to_inspect
+echo "veth1:1,veth2:1" > /sys/module/kdai/parameters/trusted_interfaces
 
 echo
 echo "=== Testing DAI Accepts Packets From Trusted Interfaces ==="
 echo
 #Send and ARP Request and wait for a Response
-#Requests will default to VLAN 0, and will match with veth0 and veth3
+#Requests will default to VLAN 1, and will match with veth0 and veth3
 sudo ip netns exec ns1 python3 ./helperPythonFilesForCustomPackets/ARP_Request_And_Response_Without_VLAN_ID.py
 
 ARP_DROP_STATUS=$(sudo dmesg | tail -n 20 | grep "ACCEPTING")

--- a/tests/Test_Untrusted_Interfaces.sh
+++ b/tests/Test_Untrusted_Interfaces.sh
@@ -59,7 +59,7 @@ echo
 echo "=== Running make load_with_params to insert the module ==="
 echo
 make -C .. install
-echo "1,10" > /sys/module/kdai/parameters/vlans_to_inspect
+sudo echo "1,10" > /sys/module/kdai/parameters/vlans_to_inspect
 
 echo
 echo "=== Testing DAI Accepts Packets From Untrusted Interfaces ==="

--- a/tests/Test_Untrusted_Interfaces.sh
+++ b/tests/Test_Untrusted_Interfaces.sh
@@ -59,7 +59,7 @@ echo
 echo "=== Running make load_with_params to insert the module ==="
 echo
 make -C .. install
-sudo echo "1,10" > /sys/module/kdai/parameters/vlans_to_inspect
+echo "1,10" | sudo tee /sys/module/kdai/parameters/vlans_to_inspect
 
 echo
 echo "=== Testing DAI Accepts Packets From Untrusted Interfaces ==="

--- a/tests/Test_Untrusted_Interfaces.sh
+++ b/tests/Test_Untrusted_Interfaces.sh
@@ -58,14 +58,14 @@ make -C ..
 echo
 echo "=== Running make load_with_params to insert the module ==="
 echo
-make -C .. load_with_params
-sudo modprobe kdai vlans_to_inspect="0,10"
+make -C .. install
+echo "1,10" > /sys/module/kdai/parameters/vlans_to_inspect
 
 echo
 echo "=== Testing DAI Accepts Packets From Untrusted Interfaces ==="
 echo
 #Send and ARP Request and wait for a Response
-#Requests will default to VLAN 0, and will match with veth0 and veth3
+#Requests will default to VLAN 1, and will match with veth0 and veth3
 sudo ip netns exec ns1 python3 ./helperPythonFilesForCustomPackets/ARP_Request_And_Response_Without_VLAN_ID.py
 
 ARP_EXIT_STATUS=$(sudo dmesg | tail -n 100 | grep "Interface is UNTRUSTED")

--- a/tests/Test_add_VLAN_to_Inspect.sh
+++ b/tests/Test_add_VLAN_to_Inspect.sh
@@ -59,7 +59,7 @@ echo
 echo "=== Running make load_with_params to insert the module ==="
 echo
 make -C .. install
-echo "10" > /sys/module/kdai/parameters/vlans_to_inspect
+sudo echo "10" > /sys/module/kdai/parameters/vlans_to_inspect
 
 echo
 echo "=== Testing DAI compares VLAN_IDs to added entries ==="

--- a/tests/Test_add_VLAN_to_Inspect.sh
+++ b/tests/Test_add_VLAN_to_Inspect.sh
@@ -58,8 +58,8 @@ make -C ..
 echo
 echo "=== Running make load_with_params to insert the module ==="
 echo
-make -C .. load_with_params
-sudo modprobe kdai vlans_to_inspect="10"
+make -C .. install
+echo "10" > /sys/module/kdai/parameters/vlans_to_inspect
 
 echo
 echo "=== Testing DAI compares VLAN_IDs to added entries ==="
@@ -70,7 +70,7 @@ sudo ip netns exec ns1 python3 ./helperPythonFilesForCustomPackets/ARP_Request_A
 sudo ip netns exec ns1 python3 ./helperPythonFilesForCustomPackets/ARP_Request_And_Response_Without_VLAN_ID.py
 
 ARP_EXIT_STATUS=$(sudo dmesg | tail -n 100 | grep "vlan_id 10 WAS FOUND in the hash table. INSPECTING")
-ARP_EXIT_STATUS=$(sudo dmesg | tail -n 100 | grep "vlan_id 0 was NOT in the HASH TABLE")
+ARP_EXIT_STATUS=$(sudo dmesg | tail -n 100 | grep "vlan_id 1 was NOT in the HASH TABLE")
 
 echo
 echo "Test Passed!"          

--- a/tests/Test_add_VLAN_to_Inspect.sh
+++ b/tests/Test_add_VLAN_to_Inspect.sh
@@ -59,7 +59,7 @@ echo
 echo "=== Running make load_with_params to insert the module ==="
 echo
 make -C .. install
-echo "1,10" | sudo tee /sys/module/kdai/parameters/vlans_to_inspect
+echo "10" | sudo tee /sys/module/kdai/parameters/vlans_to_inspect
 
 echo
 echo "=== Testing DAI compares VLAN_IDs to added entries ==="

--- a/tests/Test_add_VLAN_to_Inspect.sh
+++ b/tests/Test_add_VLAN_to_Inspect.sh
@@ -59,7 +59,7 @@ echo
 echo "=== Running make load_with_params to insert the module ==="
 echo
 make -C .. install
-sudo echo "10" > /sys/module/kdai/parameters/vlans_to_inspect
+echo "1,10" | sudo tee /sys/module/kdai/parameters/vlans_to_inspect
 
 echo
 echo "=== Testing DAI compares VLAN_IDs to added entries ==="

--- a/tests/Test_globally_enabled_DAI.sh
+++ b/tests/Test_globally_enabled_DAI.sh
@@ -59,7 +59,7 @@ echo
 echo "=== Running make load_with_params to insert the module ==="
 echo
 make -C .. install
-echo "1,10" > /sys/module/kdai/parameters/vlans_to_inspect
+sudo echo "1,10" > /sys/module/kdai/parameters/vlans_to_inspect
 echo 1 > /sys/module/kdai/parameters/globally_enabled_DAI
 
 echo

--- a/tests/Test_globally_enabled_DAI.sh
+++ b/tests/Test_globally_enabled_DAI.sh
@@ -59,8 +59,8 @@ echo
 echo "=== Running make load_with_params to insert the module ==="
 echo
 make -C .. install
-sudo echo "1,10" > /sys/module/kdai/parameters/vlans_to_inspect
-echo 1 > /sys/module/kdai/parameters/globally_enabled_DAI
+echo "1,10" | sudo tee /sys/module/kdai/parameters/vlans_to_inspect
+echo 1 | sudo tee /sys/module/kdai/parameters/globally_enabled_DAI
 
 echo
 echo "=== Testing DAI Inspects all packets ==="

--- a/tests/Test_globally_enabled_DAI.sh
+++ b/tests/Test_globally_enabled_DAI.sh
@@ -58,8 +58,9 @@ make -C ..
 echo
 echo "=== Running make load_with_params to insert the module ==="
 echo
-make -C .. load_with_params
-sudo modprobe kdai vlans_to_inspect="0,10" globally_enabled_DAI=1
+make -C .. install
+echo "1,10" > /sys/module/kdai/parameters/vlans_to_inspect
+echo 1 > /sys/module/kdai/parameters/globally_enabled_DAI
 
 echo
 echo "=== Testing DAI Inspects all packets ==="

--- a/tests/Test_static_ACL_Enabled.sh
+++ b/tests/Test_static_ACL_Enabled.sh
@@ -60,7 +60,7 @@ echo "=== Running make load_with_params to insert the module ==="
 echo
 make -C .. install
 echo "1,10" | sudo tee /sys/module/kdai/parameters/vlans_to_inspect
-echo 1 > /sys/module/kdai/parameters/static_ACL_Enabled
+echo 1 | sudo tee /sys/module/kdai/parameters/static_ACL_Enabled
 
 echo
 echo "=== Testing DAI rejcets all non Static Configurations ==="

--- a/tests/Test_static_ACL_Enabled.sh
+++ b/tests/Test_static_ACL_Enabled.sh
@@ -59,7 +59,7 @@ echo
 echo "=== Running make load_with_params to insert the module ==="
 echo
 make -C .. install
-echo "1,10" > /sys/module/kdai/parameters/vlans_to_inspect
+sudo echo "1,10" > /sys/module/kdai/parameters/vlans_to_inspect
 echo 1 > /sys/module/kdai/parameters/static_ACL_Enabled
 
 echo

--- a/tests/Test_static_ACL_Enabled.sh
+++ b/tests/Test_static_ACL_Enabled.sh
@@ -58,8 +58,9 @@ make -C ..
 echo
 echo "=== Running make load_with_params to insert the module ==="
 echo
-make -C .. load_with_params
-sudo modprobe kdai vlans_to_inspect="0,10" static_ACL_Enabled=1
+make -C .. install
+echo "1,10" > /sys/module/kdai/parameters/vlans_to_inspect
+echo 1 > /sys/module/kdai/parameters/static_ACL_Enabled
 
 echo
 echo "=== Testing DAI rejcets all non Static Configurations ==="

--- a/tests/Test_static_ACL_Enabled.sh
+++ b/tests/Test_static_ACL_Enabled.sh
@@ -59,7 +59,7 @@ echo
 echo "=== Running make load_with_params to insert the module ==="
 echo
 make -C .. install
-sudo echo "1,10" > /sys/module/kdai/parameters/vlans_to_inspect
+echo "1,10" | sudo tee /sys/module/kdai/parameters/vlans_to_inspect
 echo 1 > /sys/module/kdai/parameters/static_ACL_Enabled
 
 echo

--- a/trustedInterfaces.c
+++ b/trustedInterfaces.c
@@ -164,7 +164,7 @@ void parse_interfaces_and_vlan(char * interfaces_and_vlan) {
     char *to_free;
     u16 vlan_id;
 
-    if(interfaces_and_vlan==NULL){
+    if(interfaces_and_vlan==NULL || *interfaces_and_vlan=='\0'){
         return;
     }
 

--- a/trustedInterfaces.c
+++ b/trustedInterfaces.c
@@ -33,16 +33,32 @@ void populate_trusted_interface_list(void) {
  * a message is printed to indicate the enw addition.asm
  * 
  * Return: This fucntion returns 1 if the interface name was added, 0 if it already exists,
- * and -1 if mmory allocaiton failed
+ * and -1 if mmory allocaiton failed, -2 if interface was not found, -3 if vlan id was invalid
  */
 int insert_trusted_interface(const char *device_name, u16 vlan_id) {
-
+    struct net_device *dev;
     struct interface_entry *new_entry;
     unsigned long flags;
 
     //If we found that device already return
     if(find_trusted_interface(device_name, vlan_id)){
         return 0;
+    }
+
+    // Check if the interface exists
+    dev = dev_get_by_name(&init_net, device_name);
+    if (!dev) {
+        printk(KERN_INFO "Interface not found: %s\n", device_name);
+        return -2;
+    }
+
+    // Release Interface after use
+    dev_put(dev);
+
+    // Check if VLAN ID is within valid range (1-4094)
+    if (vlan_id < 1 || vlan_id >= 4095) {
+        printk(KERN_INFO "Invalid VLAN ID: %u. Must be between 1 (Default All) and 4094.\n", vlan_id);
+        return -3;
     }
 
     // Allocate memory for the new entry

--- a/vlan.c
+++ b/vlan.c
@@ -26,9 +26,16 @@ void init_vlan_hash_table(void) {
 
 // Add VLAN to be inspected
 void add_vlan_to_inspect(u16 vlan_id) {
-    unsigned int hash = vlan_hash(vlan_id);
+    unsigned int hash;
     struct vlan_hash_entry *entry;
     unsigned long flags;
+    
+    // Check if VLAN ID is within valid range (1-4094)
+    if (vlan_id < 1 || vlan_id >= 4095) {
+        printk(KERN_INFO "Invalid VLAN ID: %u. Must be between 1 (Default All) and 4094.\n", vlan_id);
+        return;
+    }
+    hash = vlan_hash(vlan_id);
     spin_lock_irqsave(&vlan_lock, flags);
 
     // Check if the VLAN already exists
@@ -159,6 +166,7 @@ void parse_vlans(char * vlans) {
 
         //Conver the token into an unsigned 16 bit integer
         if(kstrtou16(token, 10, &vlan_id) == 0){
+
             //After converting add the vlan to the inpsection list
             add_vlan_to_inspect(vlan_id); 
         } else {

--- a/vlan.c
+++ b/vlan.c
@@ -143,7 +143,7 @@ void parse_vlans(char * vlans) {
     char * str;
     char *to_free;
 
-    if(vlans==NULL){
+    if(vlans==NULL || *vlans =='\0'){
         return;
     }
 


### PR DESCRIPTION
Implemented dynamic kernel module parameters to configure global DAI inspection, static ACLs, VLANs to inspect, and trusted interfaces. These parameters enable runtime modifications of packet inspection settings, including toggling global DAI, controlling static ACLs, specifying VLANs for inspection, and defining trusted interfaces.

New parameter handlers were added for managing these settings, with enhanced logging for changes. Also added basic error checking to ensure interfaces exist, VLANs are valid (with default VLAN ID set to 1), and that parsing is skipped for empty strings.

Test cases now load the kernel module first and validate features through dynamically loaded parameters to intended administrator usage of DAI.